### PR TITLE
fixes #38 output of get_afltables_stats() is no longer grouped

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@
 * fixed bug where certain games from early 1900 were missing. Thanks to [Tony](https://twitter.com/MatterOfStats) [#31](https://github.com/jimmyday12/fitzRoy/issues/31)
 * fixed bug with `get_afltables_player_ids` where it was returning 0 for all players [#34](https://github.com/jimmyday12/fitzRoy/issues/34)
 * fixed bug with `get_afltables_player_ids` where it was returning 0 for GWS and Bulldogs players
+* fixed bug with `get_afltables_stats()` where it was returning a grouped `tibble`. Thanks to [tyluRp](https://github.com/tyluRp) [#38](https://github.com/jimmyday12/fitzRoy/issues/38)
 
 
 # fitzRoy 0.1.5

--- a/R/afltables_player.R
+++ b/R/afltables_player.R
@@ -43,7 +43,8 @@ get_afltables_stats <- function(start_date = "1897-01-01", end_date = Sys.Date()
     dat <- dplyr::bind_rows(dat, dat_new)
   }
   message("Finished getting afltables data")
-  dplyr::filter(dat, Date > start_date & Date < end_date)
+  dplyr::filter(dat, Date > start_date & Date < end_date) %>% 
+    ungroup()
 }
 
 #' Return match URLs for specified dates


### PR DESCRIPTION
```r
get_afltables_stats(start_date = "2000-01-01", end_date = "2001-01-01")

Returning data from 2000-01-01 to 2001-01-01
Finished getting afltables data
# A tibble: 8,140 x 59
   Season Round Date       Local.start.time Venue Attendance Home.team  HQ1G  HQ1B  HQ2G
    <dbl> <chr> <date>                <int> <chr>      <int> <chr>     <int> <int> <int>
 1   2000 1     2000-03-11             1450 Foot…      37222 Adelaide      3     2     9
 2   2000 1     2000-03-11             1450 Foot…      37222 Adelaide      3     2     9
 3   2000 1     2000-03-11             1450 Foot…      37222 Adelaide      3     2     9
 4   2000 1     2000-03-11             1450 Foot…      37222 Adelaide      3     2     9
 5   2000 1     2000-03-11             1450 Foot…      37222 Adelaide      3     2     9
 6   2000 1     2000-03-11             1450 Foot…      37222 Adelaide      3     2     9
 7   2000 1     2000-03-11             1450 Foot…      37222 Adelaide      3     2     9
 8   2000 1     2000-03-11             1450 Foot…      37222 Adelaide      3     2     9
 9   2000 1     2000-03-11             1450 Foot…      37222 Adelaide      3     2     9
10   2000 1     2000-03-11             1450 Foot…      37222 Adelaide      3     2     9
# ... with 8,130 more rows, and 49 more variables: HQ2B <int>, HQ3G <int>, HQ3B <int>,
#   HQ4G <int>, HQ4B <int>, Home.score <int>, Away.team <chr>, AQ1G <int>, AQ1B <int>,
#   AQ2G <int>, AQ2B <int>, AQ3G <int>, AQ3B <int>, AQ4G <int>, AQ4B <int>,
#   Away.score <int>, First.name <chr>, Surname <chr>, ID <int>, Jumper.No. <dbl>,
#   Playing.for <chr>, Kicks <dbl>, Marks <dbl>, Handballs <dbl>, Goals <dbl>,
#   Behinds <dbl>, Hit.Outs <dbl>, Tackles <dbl>, Rebounds <dbl>, Inside.50s <dbl>,
#   Clearances <dbl>, Clangers <dbl>, Frees.For <dbl>, Frees.Against <dbl>,
#   Brownlow.Votes <dbl>, Contested.Possessions <dbl>, Uncontested.Possessions <dbl>,
#   Contested.Marks <dbl>, Marks.Inside.50 <dbl>, One.Percenters <dbl>, Bounces <dbl>,
#   Goal.Assists <dbl>, Time.on.Ground.. <int>, Substitute <int>, Umpire.1 <chr>,
#   Umpire.2 <chr>, Umpire.3 <chr>, Umpire.4 <chr>, group_id <int>
```