### PR TITLE
Fix finals round numbers

### DIFF
--- a/tests/testthat/test-footywire.R
+++ b/tests/testthat/test-footywire.R
@@ -44,3 +44,12 @@ test_that("get_fixture filters out unplayed matches ", {
 test_that("included data is unique", {
   expect_false(any(duplicated(names(player_stats))))
 })
+
+test_that("round numbers don't increment across bye weeks without matches", {
+  max_round_lag <- get_fixture(2019)$Round %>%
+    unique %>%
+    (function(round) { round - lag(round, default = 0) }) %>%
+    max
+
+  expect_equal(max_round_lag, 1)
+})

--- a/tests/testthat/test-womens_stats.R
+++ b/tests/testthat/test-womens_stats.R
@@ -20,9 +20,9 @@ test_that("get_aflw_rounds returns data frame with correct variables", {
   expect_equal(
     colnames(get_aflw_rounds(get_aflw_cookie())),
     c(
-      "name", "id", "roundPhase", "currentRoundId", "name1",
-      "year", "season", "roundId", "abbreviation", "competitionId",
-      "roundNumber", "guid"
+      "name", "id", "roundPhase", "name1", "year",
+      "season", "roundId", "abbreviation", "competitionId",
+      "roundNumber", "guid", "currentRoundId"
     )
   )
 })


### PR DESCRIPTION
The fixture round numbers have been off by one for the last couple of rounds due to how the code was accounting for weeks without matches. This adds a cumulative sum of lag between round numbers and week counts, which should propagate the round-number adjustment for the rest of a given season.

I had a difficult time getting the grouping  and cumulative sum calculation to play nice together, so I'm open to suggestions if there's a simpler way to handle it.

I also reordered the expected column names for `get_aflw_rounds` to fix a test that was failing.