### PR TITLE
Fix betting team names

### DIFF
--- a/R/afltables_basic.R
+++ b/R/afltables_basic.R
@@ -115,6 +115,23 @@ replace_teams <- function(team) {
     team == "StK" ~ "St Kilda",
     team == "PA" ~ "Port Adelaide",
     team == "WCE" ~ "West Coast",
+    team == "Tigers" ~ "Richmond",
+    team == "Blues" ~ "Carlton",
+    team == "Demons" ~ "Melbourne",
+    team == "Giants" ~ "GWS",
+    team == "GWS Giants" ~ "GWS",
+    team == "Suns" ~ "Gold Coast",
+    team == "Bombers" ~ "Essendon",
+    team == "Swans" ~ "Sydney",
+    team == "Magpies" ~ "Collingwood",
+    team == "Crows" ~ "Adelaide",
+    team == "Bulldogs" ~ "Footscray",
+    team == "Dockers" ~ "Fremantle",
+    team == "Power" ~ "Port Adelaide",
+    team == "Saints" ~ "St Kilda",
+    team == "Eagles" ~ "West Coast",
+    team == "Cats" ~ "Geelong",
+    team == "Hawks" ~ "Hawthorn",
     TRUE ~ team
   )
 }

--- a/R/footywire-calcs.R
+++ b/R/footywire-calcs.R
@@ -187,7 +187,7 @@ calculate_round <- function(data_frame) {
       week_count = lubridate::epiweek(.data$Date),
       day_of_week = lubridate::wday(.data$Date),
       Round = ifelse(
-        between(.data$day_of_week, monday, wednesday),
+        dplyr::between(.data$day_of_week, monday, wednesday),
         .data$week_count - 1,
         .data$week_count
       ),

--- a/R/footywire-calcs.R
+++ b/R/footywire-calcs.R
@@ -509,5 +509,6 @@ get_footywire_betting_odds <- function(
     dplyr::rename_if(., names(.) %>% grepl("_home$|_away$", .), 
                      rename_home_away_columns) %>%
     calculate_round(.) %>%
+    dplyr::mutate_at(c("Home.Team", "Away.Team"), replace_teams) %>%
     dplyr::arrange(.data$Date)
 }


### PR DESCRIPTION
Resolves #90 

When working on the betting data feature, I didn't realise team names are normalised across data sources in `fitzRoy`, so I updated the team names in `replace_teams` and added the function to `get_footywire_betting_odds`