### PR TITLE
Fix round number for Wednesday matches

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,7 +7,7 @@
 * Addition of `replace_venues` - changes venue names for all data sources to match AFL Tables ([#15](https://github.com/jimmyday12/fitzRoy/issues/15), [@cfranklin11](https://github.com/cfranklin11))
 
 ## Bug Fixes
-* Fixed incorrect round numbers for fixture and betting data from `footywire.com` ([#93](https://github.com/jimmyday12/fitzRoy/issues/93), [@cfranklin11](https://github.com/cfranklin11))
+* Fixed incorrect round numbers for fixture and betting data from `footywire.com` ([#93](https://github.com/jimmyday12/fitzRoy/issues/93) & [#95](https://github.com/jimmyday12/fitzRoy/issues/95), [@cfranklin11](https://github.com/cfranklin11))
 
 # fitzRoy 0.2.0
 This release is in preparation for a CRAN submission. There are some breaking changes and removal of early functions that are no longer supported. 

--- a/tests/testthat/test-footywire.R
+++ b/tests/testthat/test-footywire.R
@@ -93,6 +93,15 @@ test_that("round 5, 2018 is calculated correctly for betting data", {
   expect_equal(nrow(round_5_data), 9)
 })
 
+test_that("Wednesday matches are at start of round by default", {
+  testthat::skip_on_cran()
+  max_matches_per_round <- 9
+  betting_data <- get_footywire_betting_odds(2019, 2019)
+  # Round 6, 2019 has a Wednesday match
+  round_6_data <- betting_data %>% dplyr::filter(Round == 6)
+  expect_equal(nrow(round_6_data), 9)
+})
+
 test_that("minimum rounds are calculated per season", {
   testthat::skip_on_cran()
   # 2014 season starts in week 11, most others start in week 12
@@ -102,14 +111,14 @@ test_that("minimum rounds are calculated per season", {
   expect_equal(min(betting_data_2015$Round), 1)
 })
 
-test_that("round weeks are calculated from wednesday to monday", {
+test_that("round weeks are calculated from Thursday to Wednesday", {
   testthat::skip_on_cran()
   betting_data <- get_footywire_betting_odds(2010, 2010)
   round_1_data = betting_data %>% dplyr::filter(Round == 1)
 
-  # If epiweeks aren't adjusted properly (Sunday to Wednesday), the first round
-  # of 2010 will only have 5 matches due to 3 taking place on Sunday (the start
-  # of a new epiweek)
+  # If epiweeks aren't adjusted properly (Sunday to Wednesday belong
+  # to previous week), the first round of 2010 will only have 5 matches
+  # due to 3 taking place on Sunday (the start of a new epiweek)
   expect_equal(nrow(round_1_data), 8)
 })
 


### PR DESCRIPTION
Resolves #95 

As with other recent bugs for footywire round number calculations,
I'm a bit confused as to what changed regarding how weeks and
weekdays are counted to cause this, but something moved Wednesdays
from the beginning to the end of the round week by default.

Changing the between filter to use Sunday and Tuesday as the limits
makes the default round week Wednesday to Tuesday as intended.