### PR TITLE
Calculate cumulative lag by Season group

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,7 +7,7 @@
 * Addition of `replace_venues` - changes venue names for all data sources to match AFL Tables ([#15](https://github.com/jimmyday12/fitzRoy/issues/15), [@cfranklin11](https://github.com/cfranklin11))
 
 ## Bug Fixes
-* Fixed incorrect round numbers for fixture and betting data from `footywire.com` ([#93](https://github.com/jimmyday12/fitzRoy/issues/93) & [#95](https://github.com/jimmyday12/fitzRoy/issues/95), [@cfranklin11](https://github.com/cfranklin11))
+* Fixed incorrect round numbers for fixture and betting data from `footywire.com` ([#93](https://github.com/jimmyday12/fitzRoy/issues/93) & [#95](https://github.com/jimmyday12/fitzRoy/issues/95) & [#102](https://github.com/jimmyday12/fitzRoy/issues/102), [@cfranklin11](https://github.com/cfranklin11))
 
 # fitzRoy 0.2.0
 This release is in preparation for a CRAN submission. There are some breaking changes and removal of early functions that are no longer supported. 

--- a/man/get_footywire_betting_odds.Rd
+++ b/man/get_footywire_betting_odds.Rd
@@ -4,10 +4,8 @@
 \alias{get_footywire_betting_odds}
 \title{Get AFL match betting odds from https://www.footywire.com}
 \usage{
-get_footywire_betting_odds(
-  start_season = "2010",
-  end_season = lubridate::year(Sys.Date())
-)
+get_footywire_betting_odds(start_season = "2010",
+  end_season = lubridate::year(Sys.Date()))
 }
 \arguments{
 \item{start_season}{First season to return, in yyyy format. Earliest season with data available is 2010.}

--- a/man/get_squiggle_data.Rd
+++ b/man/get_squiggle_data.Rd
@@ -4,10 +4,8 @@
 \alias{get_squiggle_data}
 \title{Access Squiggle data using the squiggle API service.}
 \usage{
-get_squiggle_data(
-  query = c("sources", "games", "tips", "ladder", "standings"),
-  ...
-)
+get_squiggle_data(query = c("sources", "games", "tips", "ladder",
+  "standings"), ...)
 }
 \arguments{
 \item{query}{A text string. The main query to use with the API. Must be one of \code{sources}, \code{games}, \code{tips}, \code{ladder} or \code{standings}}

--- a/tests/testthat/test-footywire.R
+++ b/tests/testthat/test-footywire.R
@@ -122,6 +122,15 @@ test_that("round weeks are calculated from Thursday to Wednesday", {
   expect_equal(nrow(round_1_data), 8)
 })
 
+test_that("no season has a Round of 0", {
+  testthat::skip_on_cran()
+  # A bug caused rounds 2017 through 2019 to start at Round 0
+  betting_data <- get_footywire_betting_odds(2016, 2017)
+  round_0_data = betting_data %>% dplyr::filter(Round == 0)
+
+  expect_equal(nrow(round_0_data), 0)
+})
+
 test_that("update_footywire_stats works ", {
   testthat::skip_on_cran()
 fw_dat <- update_footywire_stats()


### PR DESCRIPTION
Resolves #102 

Not separating out the nesting by Season and Round led to
calculating round lag (due to bye weeks) across seasons,
resulting in seasons 2017 through 2019 starting with a Round of
zero.