### PR TITLE
Fix 2019 rounds

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,7 +7,7 @@
 * Addition of `replace_venues` - changes venue names for all data sources to match AFL Tables ([#15](https://github.com/jimmyday12/fitzRoy/issues/15), [@cfranklin11](https://github.com/cfranklin11))
 
 ## Bug Fixes
-* Fixed incorrect round numbers for fixture and betting data from `footywire.com` ([#93](https://github.com/jimmyday12/fitzRoy/issues/93) & [#95](https://github.com/jimmyday12/fitzRoy/issues/95) & [#102](https://github.com/jimmyday12/fitzRoy/issues/102), [@cfranklin11](https://github.com/cfranklin11))
+* Fixed incorrect round numbers for fixture and betting data from `footywire.com` ([#93](https://github.com/jimmyday12/fitzRoy/issues/93), [#95](https://github.com/jimmyday12/fitzRoy/issues/95), [#102](https://github.com/jimmyday12/fitzRoy/issues/102) & [#104](https://github.com/jimmyday12/fitzRoy/issues/104), [@cfranklin11](https://github.com/cfranklin11))
 
 # fitzRoy 0.2.0
 This release is in preparation for a CRAN submission. There are some breaking changes and removal of early functions that are no longer supported. 

--- a/R/footywire-calcs.R
+++ b/R/footywire-calcs.R
@@ -160,8 +160,8 @@ calculate_round <- function(data_frame) {
         .$data %>%
         # Expand max lag to have same length as match count.
         purrr::map(~ rep.int(calculate_max_lag(.x$weeks_since_last_match), nrow(.x))) %>%
-        unlist %>%
-        cumsum
+        purrr::accumulate(~ max(.x) + .y) %>%
+        unlist
     }
 
     gap_df %>%


### PR DESCRIPTION
Resolves #104 

A fix to how cumulative round lag was calculated across seasons resulted in a new bug in how cumulative round lag was calculated after a bye week. This caused an inflated cumulative lag number, which resulted in round numbers that went up and down and up again.

In addition to fixing this particular bug, I reorganised the relevant tests in an effort to catch these kinds of regressions in the future. Loading multiple seasons of betting data and making assertions on general characteristics of the data should do a better job of catching future bugs than the more specific tests for edge cases.