### PR TITLE
Fix round numbers for seasons with two-week rounds

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,7 +7,7 @@
 * Addition of `replace_venues` - changes venue names for all data sources to match AFL Tables ([#15](https://github.com/jimmyday12/fitzRoy/issues/15), [@cfranklin11](https://github.com/cfranklin11))
 
 ## Bug Fixes
-* Fixed incorrect round numbers for fixture and betting data from `footywire.com` ([#93](https://github.com/jimmyday12/fitzRoy/issues/93), [#95](https://github.com/jimmyday12/fitzRoy/issues/95), [#102](https://github.com/jimmyday12/fitzRoy/issues/102) & [#104](https://github.com/jimmyday12/fitzRoy/issues/104), [@cfranklin11](https://github.com/cfranklin11))
+* Fixed incorrect round numbers for fixture and betting data from `footywire.com` ([#93](https://github.com/jimmyday12/fitzRoy/issues/93), [#95](https://github.com/jimmyday12/fitzRoy/issues/95), [#102](https://github.com/jimmyday12/fitzRoy/issues/102), [#104](https://github.com/jimmyday12/fitzRoy/issues/104), [#106](https://github.com/jimmyday12/fitzRoy/issues/106), [@cfranklin11](https://github.com/cfranklin11))
 
 # fitzRoy 0.2.0
 This release is in preparation for a CRAN submission. There are some breaking changes and removal of early functions that are no longer supported. 

--- a/R/footywire-calcs.R
+++ b/R/footywire-calcs.R
@@ -191,10 +191,9 @@ calculate_round <- function(data_frame) {
 
     # 2012-2014: first round shifts round numbers for rest of season
     round_one <- 1
-    round_indices_to_fix <- round_df$Date >= lubridate::ymd("2012-01-01") &
-      round_df$Date <= lubridate::ymd("2014-12-31")
-    round_df$Round[round_indices_to_fix] <-
-      round_df$Round[round_indices_to_fix] - 1
+    round_indices_to_fix <- round_df$Season >= 2012 & round_df$Season <= 2014
+    shifted_rounds <- round_df$Round[round_indices_to_fix] - 1
+    round_df$Round[round_indices_to_fix] <- shifted_rounds
     round_df$Round[round_df$Round == 0] <- round_one
 
     # Round 13, 2010 and Round 18, 2014 each last two weeks, so we need to shift

--- a/R/footywire-calcs.R
+++ b/R/footywire-calcs.R
@@ -203,6 +203,13 @@ calculate_round <- function(data_frame) {
     shifted_rounds <- round_df$Round[round_indices_to_fix] - 1
     round_df$Round[round_indices_to_fix] <- shifted_rounds
 
+    # The 2010 Grand Final was replayed a week after the initial draw.
+    # AFLTables labels both matches as being in round 26, so we'll do the same
+    # here
+    round_twenty_six <- 26
+    round_indices_to_fix <- round_df$Round >= 26 & round_df$Season == 2010
+    round_df$Round[round_indices_to_fix] <- round_twenty_six
+
     round_df
   }
 

--- a/R/footywire-calcs.R
+++ b/R/footywire-calcs.R
@@ -197,6 +197,13 @@ calculate_round <- function(data_frame) {
       round_df$Round[round_indices_to_fix] - 1
     round_df$Round[round_df$Round == 0] <- round_one
 
+    # Round 13, 2010 and Round 18, 2014 each last two weeks, so we need to shift
+    # all subsequent rounds down by one
+    round_indices_to_fix <- (round_df$Round > 13 & round_df$Season == 2010) |
+      (round_df$Round > 18 & round_df$Season == 2014)
+    shifted_rounds <- round_df$Round[round_indices_to_fix] - 1
+    round_df$Round[round_indices_to_fix] <- shifted_rounds
+
     round_df
   }
 
@@ -228,8 +235,8 @@ calculate_round <- function(data_frame) {
 
   round_df <- data_frame %>%
     calculate_round_by_week(.) %>%
-    fix_incorrect_rounds(.) %>%
-    remove_bye_round_gaps(.)
+    remove_bye_round_gaps(.) %>%
+    fix_incorrect_rounds(.)
 }
 
 

--- a/tests/testthat/test-footywire.R
+++ b/tests/testthat/test-footywire.R
@@ -116,7 +116,7 @@ describe("get_footywire_betting_odds", {
   it("doesn't have any duplicate Season/Round/Team combinations", {
     home_df <- full_betting_df %>% dplyr::mutate(Team = .data$Home.Team)
     away_df <- full_betting_df %>% dplyr::mutate(Team = .data$Away.Team)
-    combined_df = dplyr::bind_rows(c(home_df, away_df))
+    combined_df <- dplyr::bind_rows(c(home_df, away_df))
 
     expect_equal(nrow(combined_df), nrow(dplyr::distinct(combined_df)))
   })
@@ -138,7 +138,7 @@ describe("get_footywire_betting_odds", {
     # If epiweeks aren't adjusted properly (Sunday to Wednesday belong
     # to previous week), the first round of 2010 will only have 5 matches
     # due to 3 taking place on Sunday (the start of a new epiweek)
-    round_1_data = full_betting_df %>% dplyr::filter(Season == 2010, Round == 1)
+    round_1_data <- full_betting_df %>% dplyr::filter(Season == 2010, Round == 1)
     expect_equal(nrow(round_1_data), 8)
   })
 

--- a/tests/testthat/test-footywire.R
+++ b/tests/testthat/test-footywire.R
@@ -152,6 +152,18 @@ describe("get_footywire_betting_odds", {
     expect_equal(nrow(round_13_2010), 8)
     expect_equal(nrow(round_18_2014), 9)
   })
+
+  it("labels both Grand Finals in 2010 with the same round", {
+    round_26__2010 <- full_betting_df %>%
+      dplyr::filter(Round == 26, Season == 2010)
+
+    expect_equal(nrow(round_26__2010), 2)
+
+    bonus_rounds <- full_betting_df %>%
+      dplyr::filter(Round > 26, Season == 2010)
+
+    expect_equal(nrow(bonus_rounds), 0)
+  })
 })
 
 test_that("update_footywire_stats works ", {

--- a/tests/testthat/test-footywire.R
+++ b/tests/testthat/test-footywire.R
@@ -141,6 +141,17 @@ describe("get_footywire_betting_odds", {
     round_1_data = full_betting_df %>% dplyr::filter(Season == 2010, Round == 1)
     expect_equal(nrow(round_1_data), 8)
   })
+
+  it("accounts for 2-week rounds in 2010 and 2014", {
+    round_13_2010 <- full_betting_df %>%
+      dplyr::filter(Round == 13, Season == 2010)
+
+    round_18_2014 <- full_betting_df %>%
+      dplyr::filter(Round == 18, Season == 2014)
+
+    expect_equal(nrow(round_13_2010), 8)
+    expect_equal(nrow(round_18_2014), 9)
+  })
 })
 
 test_that("update_footywire_stats works ", {


### PR DESCRIPTION
Resolves #106 

Round 13 in 2010 and round 18 in 2014 span two weeks, which means we were labelling them as two separate rounds, which increased the round number for all subsequent rounds. Also, the 2010 Grand Final was played twice due to a draw, resulting in the same issue.

This fixes up the offending round numbers similarly to how we handle other special cases of the AFL's scheduling inconsistencies and adds a couple of tests.

On a side note, these round number bugs are difficult to catch on their own, and I've been finding most of them when running the Footywire betting data through my full data pipeline, because various transformations and joins depend on absolute consistency. To be on the safe side, I ran these changes through the entire pipeline (I had been too lazy to do it before), and it completed without error. So, I'm hopeful this will be the last round-related bug fix for awhile.