### PR TITLE
Return empty data frame if data set is blank

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # fitzRoy (development version)
 
+## Bug Fixes
+* Fixed `get_footywire_betting_odds` to return an empty data frame when only future seasons are requested rather than raising an error ([#112](https://github.com/jimmyday12/fitzRoy/issues/112), [@cfranklin11](https://github.com/cfranklin11))
+
 # fitzRoy 0.3.1
 
 * Updating vignettes to use internal data rather than downloading from the internet

--- a/man/get_footywire_betting_odds.Rd
+++ b/man/get_footywire_betting_odds.Rd
@@ -4,10 +4,8 @@
 \alias{get_footywire_betting_odds}
 \title{Get AFL match betting odds from https://www.footywire.com}
 \usage{
-get_footywire_betting_odds(
-  start_season = "2010",
-  end_season = lubridate::year(Sys.Date())
-)
+get_footywire_betting_odds(start_season = "2010",
+  end_season = lubridate::year(Sys.Date()))
 }
 \arguments{
 \item{start_season}{First season to return, in yyyy format. Earliest season with data available is 2010.}

--- a/tests/testthat/test-footywire.R
+++ b/tests/testthat/test-footywire.R
@@ -177,6 +177,18 @@ describe("get_footywire_betting_odds", {
 
     expect_equal(nrow(bonus_rounds), 0)
   })
+
+  it("returns an empty data frame when a future season is requested", {
+    this_year <- as.numeric(lubridate::year(Sys.Date()))
+    next_year <- this_year + 1
+
+    empty_betting_df <- get_footywire_betting_odds(
+      start_season = next_year, end_season = next_year
+    )
+
+    expect_equal(nrow(empty_betting_df), 0)
+    expect_equal(colnames(empty_betting_df), colnames(full_betting_df))
+  })
 })
 
 test_that("update_footywire_stats works ", {


### PR DESCRIPTION
Resolves #112

In the case of only requesting a season that hasn't been played
yet, the `NULL` returned by `unlist` caused an error later in the
chain of functions. This handles empty data more gracefully.