### PR TITLE
Add Match.ID column to guarantee unique ID columns for pivot

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,9 @@
 * Added AFL stats [@fryzigg](https://github.com/Fryzigg)
 * Added team colours [@fryzigg](https://github.com/Fryzigg)
 
+## Bug Fixes
+* Fixed `get_footywire_betting_odds` to handle duplicate date/venue combination in the 2020 season without raising error ([#123](https://github.com/jimmyday12/fitzRoy/issues/123), [@cfranklin11](https://github.com/cfranklin11))
+
 # fitzRoy 0.3.2
 
 ## General changes

--- a/R/footywire-calcs.R
+++ b/R/footywire-calcs.R
@@ -562,7 +562,10 @@ get_footywire_betting_odds <- function(
       Season = as.character(.data$Season) %>% as.numeric(.),
       # Raw betting data has two rows per match: the top team is home
       # and the bottom is away
-      Home.Away = ifelse(dplyr::row_number() %% 2 == 1, "home", "away")
+      Home.Away = ifelse(dplyr::row_number() %% 2 == 1, "home", "away"),
+      # We need a unique Match.ID to pivot rows correctly, because there are
+      # some duplicate date/venue combinations
+      Match.ID = ceiling(seq(dplyr::row_number()) / 2)
     ) %>%
     tidyr::pivot_wider(
       .,
@@ -572,6 +575,7 @@ get_footywire_betting_odds <- function(
         .data$Win.Odds, .data$Win.Paid, .data$Line.Odds, .data$Line.Paid
       )
     ) %>%
+    dplyr::select(., !c('Match.ID')) %>%
     dplyr::rename_if(
       ., names(.) %>% grepl("_home$|_away$", .),
       rename_home_away_columns

--- a/tests/testthat/test-footywire.R
+++ b/tests/testthat/test-footywire.R
@@ -91,7 +91,7 @@ describe("get_footywire_betting_odds", {
   # Many regression tests require fetching multiple seasons,
   # so it's most efficient to fetch all years with known potential issues
   full_betting_df <- get_footywire_betting_odds(
-    start_season = 2010, end_season = 2019
+    start_season = 2010, end_season = 2020
   )
 
   it("works with different inputs ", {


### PR DESCRIPTION
With the limited number of venues for the current rounds, the
AFL has scheduled two matches for the same venue on the same day,
which breaks the uniqueness assumption for those value combinations.
Adding an ID column to facilitate pivoting fixes the error raised
from duplication causing team columns to have vectors of names
instead of individual team names.