### PR TITLE
Fix round numbers for 2020 through round 12

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -63,5 +63,5 @@ ByteCompile: true
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.1.0
+RoxygenNote: 7.1.1
 Language: en-US

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,7 @@
 
 ## Bug Fixes
 * Fixed `get_footywire_betting_odds` to handle duplicate date/venue combination in the 2020 season without raising error ([#123](https://github.com/jimmyday12/fitzRoy/issues/123), [@cfranklin11](https://github.com/cfranklin11))
+* Fixed round calculations for `get_fixture` to handle the compressed 2020 fixture ([#125](https://github.com/jimmyday12/fitzRoy/issues/125), [@cfranklin11](https://github.com/cfranklin11))
 
 # fitzRoy 0.3.2
 

--- a/R/footywire-calcs.R
+++ b/R/footywire-calcs.R
@@ -218,6 +218,27 @@ calculate_round <- function(data_frame) {
     round_indices_to_fix <- round_df$Round >= 26 & round_df$Season == 2010
     round_df$Round[round_indices_to_fix] <- round_twenty_six
 
+    # 2020, when the AFL went all John Madden on the fixture.
+    # Date ranges for rounds are based on https://www.footywire.com/afl/footy/ft_match_list
+    start_of_round_ten <- lubridate::ymd('2020-08-03')
+    start_of_round_eleven <- lubridate::ymd('2020-08-08')
+    start_of_round_twelve <- lubridate::ymd('2020-08-13')
+
+    round_ten_indices <- round_df$Date >= start_of_round_ten &
+      round_df$Date < start_of_round_eleven
+    round_eleven_indices <- round_df$Date >= start_of_round_eleven &
+      round_df$Date < start_of_round_twelve
+    round_twelve_indices <- round_df$Date >= start_of_round_twelve &
+      round_df$Date < lubridate::ymd('2020-08-18')
+
+    round_ten <- 10
+    round_eleven <- 11
+    round_twelve <- 12
+
+    round_df$Round[round_ten_indices] <- round_ten
+    round_df$Round[round_eleven_indices] <- round_eleven
+    round_df$Round[round_twelve_indices] <- round_twelve
+
     round_df
   }
 

--- a/tests/testthat/test-footywire.R
+++ b/tests/testthat/test-footywire.R
@@ -84,6 +84,27 @@ test_that("round numbers don't increment across bye weeks without matches", {
   expect_equal(calculate_max_round_lag(betting_rounds), 1)
 })
 
+test_that("2020 season round numbers are correct through round 12", {
+  testthat::skip_if_offline()
+  testthat::skip_on_cran()
+
+  # We filter for matches through round 12, because we don't want
+  # unknown, future data changes to break tests
+  fixture <- get_fixture(2020) %>% dplyr::filter(.data$Round <= 12)
+
+  n_duplicate_home_teams <- fixture %>%
+    dplyr::group_by(Season, Round, Home.Team) %>%
+    dplyr::filter(dplyr::n() > 1) %>%
+    nrow
+
+  n_duplicate_away_teams <- fixture %>%
+    dplyr::group_by(Season, Round, Home.Team) %>%
+    dplyr::filter(dplyr::n() > 1) %>%
+    nrow
+
+  expect_equal(n_duplicate_home_teams, n_duplicate_away_teams, 0)
+})
+
 describe("get_footywire_betting_odds", {
   testthat::skip_if_offline()
   testthat::skip_on_cran()


### PR DESCRIPTION
Resolves #125 

The AFL fixture has been compressed, such that each week is
going to have about a round and a half. This means that we have
to adjust round numbers for upcoming weeks based on the date
ranges of the upcoming rounds.