### PR TITLE
Extend date filters for irregular 2020 rounds

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,7 +8,7 @@
 
 ## Bug Fixes
 * Fixed `get_footywire_betting_odds` to handle duplicate date/venue combination in the 2020 season without raising error ([#123](https://github.com/jimmyday12/fitzRoy/issues/123), [@cfranklin11](https://github.com/cfranklin11))
-* Fixed round calculations for `get_fixture` to handle the compressed 2020 fixture ([#125](https://github.com/jimmyday12/fitzRoy/issues/125) and [#128](https://github.com/jimmyday12/fitzRoy/issues/128), [@cfranklin11](https://github.com/cfranklin11))
+* Fixed round calculations for `get_fixture` to handle the compressed 2020 fixture ([#125](https://github.com/jimmyday12/fitzRoy/issues/125), [#128](https://github.com/jimmyday12/fitzRoy/issues/128), [#132](https://github.com/jimmyday12/fitzRoy/issues/132), [@cfranklin11](https://github.com/cfranklin11))
 
 # fitzRoy 0.3.2
 

--- a/R/footywire-calcs.R
+++ b/R/footywire-calcs.R
@@ -241,7 +241,11 @@ calculate_round <- function(data_frame) {
       lubridate::ymd("2020-08-08"),
       lubridate::ymd("2020-08-13"),
       lubridate::ymd("2020-08-21"),
-      lubridate::ymd("2020-08-25")
+      lubridate::ymd("2020-08-25"),
+      lubridate::ymd("2020-08-31"),
+      lubridate::ymd("2020-09-05"),
+      lubridate::ymd("2020-09-10"),
+      lubridate::ymd("2020-09-15")
     ) %>%
       purrr::reduce(., assign_2020_round_by_date_range) %>%
       .$data_frame


### PR DESCRIPTION
Resolves #132 

Covers rounds 14 through 17. Dates based on fixture at https://www.footywire.com/afl/footy/ft_match_list