### PR TITLE
Fix fetching player stats & ladder

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # fitzRoy (development version)
 
 * Fixed an a bug in `fetch_fixture_footywire` for older versions of R [#146](https://github.com/jimmyday12/fitzRoy/issues/146)
+* Fixed type mismatch in `fetch_player_stats_afltables` and handling blank seasons in `fetch_ladder_afl` ([#149](https://github.com/jimmyday12/fitzRoy/issues/149), [@cfranklin11](https://github.com/cfranklin11))
 
 # fitzRoy 1.0.0
 

--- a/R/fetch-ladder.R
+++ b/R/fetch-ladder.R
@@ -100,9 +100,9 @@ fetch_ladder_afl <- function(season = NULL, round_number = NULL, comp = "AFLM") 
     round_id <- find_round_id(round_number, season_id = season_id, 
                                 comp = comp, providerId = FALSE, 
                                 future_rounds = FALSE)
-  } 
-  
-  if(is.null(round_id)) return(NULL)
+  }
+
+  if(is.null(round_id) || is.null(season_id)) return(NULL)
 
   # Make request
   api_url <- season_id %>% 

--- a/R/fetch-player-stats.R
+++ b/R/fetch-player-stats.R
@@ -155,7 +155,12 @@ fetch_player_stats_afltables <- function(season = NULL, round_number = NULL) {
     if (length(urls) != 0) {
       cli::cli_alert_info("New data found for {.val {length(urls)}} matches")
       dat_new <- scrape_afltables_match(urls)
-      dat <- dplyr::bind_rows(dat, dat_new)
+
+      dat <- list(dat, dat_new) %>%
+        # Some DFs have numeric columns as 'chr' and some have them as 'dbl',
+        # so we need to make them consistent before joining to avoid type errors
+        purrr::map(~ dplyr::mutate_at(., c("Jumper.No."), as.character)) %>%
+        dplyr::bind_rows(.)
     }
   } else {
     cli::cli_alert_info("No new data found - returning cached data")

--- a/R/helpers-afltables-playerstats.R
+++ b/R/helpers-afltables-playerstats.R
@@ -349,17 +349,27 @@ get_afltables_player_ids <- function(seasons) {
   
   ids_new <- urls %>%
     purrr::map(readUrl) %>%
+    purrr::discard(~ nrow(.x) == 0)
+
+  first_populated_season <- end - length(ids_new) + 1
+
+  # Some DFs have numeric columns as 'chr' and some have them as 'dbl',
+  # so we need to make them consistent before joining to avoid type errors
+  mixed_cols <- c('Round', 'Jumper.No.')
+  cols_to_convert <- intersect(mixed_cols, colnames(ids_new[[1]]))
+
+  ids_new <- ids_new %>%
+    purrr::map(~ dplyr::mutate_at(., cols_to_convert, as.character)) %>%
     purrr::map2_dfr(
-      .y = start:end,
+      .y = first_populated_season:end,
       ~ dplyr::mutate(., Season = .y)
-    ) 
+    )
 
   if (nrow(ids_new) < 1) {
     return(ids)
   } 
   
   ids_new <- ids_new %>%
-    dplyr::mutate(., Round = as.character(.data$Round)) %>%
     dplyr::select(!!col_vars) %>%
     dplyr::distinct() %>%
     dplyr::rename(Team.abb = .data$Team) %>%

--- a/tests/testthat/test-helpers-afltables-playerstats.R
+++ b/tests/testthat/test-helpers-afltables-playerstats.R
@@ -30,6 +30,7 @@ test_that("get_afltables_player_ids works", {
   
   expect_type(get_afltables_player_ids(1897:2020), "list")
   expect_type(get_afltables_player_ids(2017), "list")
+  expect_type(get_afltables_player_ids(2021), "list")
   expect_error(get_afltables_player_ids())
   expect_error(suppressWarnings(get_afltables_player_ids("a")))
 })


### PR DESCRIPTION
Resolves #149 

AFLTables is returning some columns (e.g. Round, Jumper.No.)
as character type for the 2020 season, but as double type for 2021,
which raises an error when we try to join the season
dataframes. We have to filter out empty dataframes before setting
the types, because they don't have columns to convert.

There was also a small bug in fetching the ladder for seasons
before 2012, because the AFL API doesn't have data going
that far back, so we return `NULL` just like when the `round_id`
is missing.