### PR TITLE
Fix round_number documentation in fetch_results

### DIFF
--- a/R/fetch-results.R
+++ b/R/fetch-results.R
@@ -9,6 +9,7 @@
 #' can be called directly and return data from AFL website, AFL Tables, Footywire and
 #' Squiggle, respectively.
 #'
+#' @param round_number Round number, defaults to NULL which returns all rounds
 #' @inheritParams fetch_ladder
 #' @return
 #' A Tibble with the results from the relevant `season` and `round`.

--- a/man/fetch_results.Rd
+++ b/man/fetch_results.Rd
@@ -32,7 +32,7 @@ fetch_results_squiggle(season = NULL, round_number = NULL)
 \item{season}{Season in YYYY format, defaults to NULL which returns the year
 corresponding the \code{Sys.Date()}}
 
-\item{round_number}{Round number, defaults to NULL which returns latest round}
+\item{round_number}{Round number, defaults to NULL which returns all rounds}
 
 \item{comp}{One of "AFLM" (default) or "AFLW"}
 


### PR DESCRIPTION
The doc for `fetch_results` inherits the parameter documentation from `fetch_ladder`. When `round_number` is NULL in `fetch_ladder` it returns the latest round, but when it is NULL in `fetch_results` it returns all rounds.

This PR overrides the inherited doc to reflect this. This also matches the behaviour documented in the main-fetch-functions vignette.