### PR TITLE
Fixes #201 - handle unique case where a player was 'unused sub'

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # fitzRoy (development version)
 
+* Fixed a bug where `fetch_footywire_stats` was breaking due to an 'unused sub' in game this year ([#201](https://github.com/jimmyday12/fitzRoy/issues/201))
+
 # fitzRoy 1.3.0
 
 * Fixed a bug where `fetch_footywire_stats` was breaking due to changes in the footywire site

--- a/R/helpers-footywire.R
+++ b/R/helpers-footywire.R
@@ -102,7 +102,12 @@ footywire_html <- function(x, id) {
       Team = home_team,
       Opposition = away_team,
       Status = "Home"
-    )
+    ) %>%
+    dplyr::mutate(dplyr::across(c(-"Player", 
+                                  -"Team",
+                                  -"Opposition", 
+                                  -"Status"), 
+                                as.numeric))
 
   # Now get the table data
   away_stats <- x %>%
@@ -113,7 +118,12 @@ footywire_html <- function(x, id) {
       Team = away_team,
       Opposition = home_team,
       Status = "Away"
-    )
+    ) %>%
+    dplyr::mutate(dplyr::across(c(-"Player", 
+                                  -"Team",
+                                  -"Opposition", 
+                                  -"Status"), 
+                                as.numeric))
 
   ## Add data to ind.table
   player_stats <- home_stats %>%

--- a/tests/testthat/test-fetch-player-stats.R
+++ b/tests/testthat/test-fetch-player-stats.R
@@ -65,6 +65,9 @@ test_that("fetch_player_stats_footywire works for various inputs", {
   gf <- fetch_player_stats_footywire(season = 2020) %>%
     dplyr::filter(Round == "Grand Final")
   expect_equal(nrow(gf), 44)
+  
+  #specific bug on a game with unused sub
+  expect_s3_class(fetch_footywire_stats(10808), "tbl")
 })
 
 test_that("fetch_player_stats_fryzigg works for various inputs", {


### PR DESCRIPTION
Fixes Issue #201 where `fetch_player_stats_footywire` was failing due to an unused sub existing in a table