### PR TITLE
Small update to documentation

### DIFF
--- a/R/fetch-squiggle-data.R
+++ b/R/fetch-squiggle-data.R
@@ -23,13 +23,13 @@
 #' @examples
 #' \dontrun{
 #' # Return a list of the sources, with ID's
-#' sources <- get_squiggle_data("sources")
+#' sources <- fetch_squiggle_data("sources")
 #'
 #' # Get tips for Round 1, 2018
-#' tips <- get_squiggle_data(query = "tips", round = 1, year = 2018)
+#' tips <- fetch_squiggle_data(query = "tips", round = 1, year = 2018)
 #'
 #' # Get tips from Squiggle 2019
-#' squiggle <- get_squiggle_data(query = "tips", source = 1, year = 2019)
+#' squiggle <- fetch_squiggle_data(query = "tips", source = 1, year = 2019)
 #' }
 fetch_squiggle_data <- function(query = c(
                                   "teams",

--- a/man/fetch_squiggle_data.Rd
+++ b/man/fetch_squiggle_data.Rd
@@ -35,12 +35,12 @@ For full instructions, see \href{https://api.squiggle.com.au}{api.squiggle.com.a
 \examples{
 \dontrun{
 # Return a list of the sources, with ID's
-sources <- get_squiggle_data("sources")
+sources <- fetch_squiggle_data("sources")
 
 # Get tips for Round 1, 2018
-tips <- get_squiggle_data(query = "tips", round = 1, year = 2018)
+tips <- fetch_squiggle_data(query = "tips", round = 1, year = 2018)
 
 # Get tips from Squiggle 2019
-squiggle <- get_squiggle_data(query = "tips", source = 1, year = 2019)
+squiggle <- fetch_squiggle_data(query = "tips", source = 1, year = 2019)
 }
 }


### PR DESCRIPTION
Noticed that the examples in the documentation for the `fetch_squiggle_data()` function were using the outdated `get_squiggle_data()` function (no longer exported) so I edited the roxygen to fix this.