### PR TITLE
Update helpers-afl.R

### DIFF
--- a/R/helpers-afl.R
+++ b/R/helpers-afl.R
@@ -35,11 +35,11 @@ fetch_teams_afl <- function(comp){
   
   
   df <- teams %>%
-    stats::na.omit() %>%
     dplyr::select(
       "id", "abbreviation",
       "name", "teamType"
-    )
+    ) %>%
+    stats::na.omit()
   
   type <- dplyr::case_when(
     comp == "AFLM" ~ "MEN",

--- a/R/helpers-afl.R
+++ b/R/helpers-afl.R
@@ -37,7 +37,8 @@ fetch_teams_afl <- function(comp){
   df <- teams %>%
     dplyr::select(
       "id", "abbreviation",
-      "name", "teamType"
+      "name", "teamType",
+      "club.id","club.providerId","club.name","club.abbreviation","club.nickname"
     ) %>%
     stats::na.omit()
   


### PR DESCRIPTION
do select before na.omit - as new metadata columns have been added to the base table which often return as NA

![fitzroy-teams-metadata](https://github.com/jimmyday12/fitzRoy/assets/15244843/800d625c-ce91-484d-8382-086171fec8a2)
