### PR TITLE
handle for edge cases in replace_teams #215

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: fitzRoy
 Title: Easily Scrape and Process AFL Data
-Version: 1.3.0.9000
+Version: 1.3.0.910
 Authors@R:
     c(person(given = "James",
              family = "Day",

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,7 @@
 * Fixed a bug where `fetch_fixture_footywire` wasn't working for season 2024 due to Opening round ([#209](https://github.com/jimmyday12/fitzRoy/issues/209))
 * Fixed a bug where `fetch_results_footywire` wasn't working for season 2024 due to Opening round ([#211](https://github.com/jimmyday12/fitzRoy/issues/211)) 
 * Updated the Squiggle API code to be more flexible
+* Updated `replace_teams` to handle for indigenous round team names and made it more robust to handle random team name variations ([#215](https://github.com/jimmyday12/fitzRoy/issues/215))
 
 
 # fitzRoy 1.3.0

--- a/R/helpers-afltables.R
+++ b/R/helpers-afltables.R
@@ -33,38 +33,44 @@ team_check_afltables <- function(team) {
 replace_teams <- function(team) {
   # Internal function
   dplyr::case_when(
-    team == "Kangaroos" ~ "North Melbourne",
+    # keeping these three as is as the initialisation could conceivably appear in another team name string and want to avoid word boundaries
     team == "NM" ~ "North Melbourne",
-    team == "Western Bulldog" ~ "Footscray",
-    team == "Western Bulldogs" ~ "Footscray",
     team == "WB" ~ "Footscray",
-    team == "South Melbourne" ~ "Sydney",
-    team == "Brisbane Bears" ~ "Brisbane Lions",
-    team == "Lions" ~ "Brisbane Lions",
-    team == "Brisbane" ~ "Brisbane Lions",
-    team == "GW Sydney" ~ "GWS",
-    team == "Greater Western Sydney" ~ "GWS",
-    team == "GC" ~ "Gold Coast",
-    team == "StK" ~ "St Kilda",
     team == "PA" ~ "Port Adelaide",
-    team == "WCE" ~ "West Coast",
-    team == "Tigers" ~ "Richmond",
-    team == "Blues" ~ "Carlton",
-    team == "Demons" ~ "Melbourne",
-    team == "Giants" ~ "GWS",
-    team == "GWS Giants" ~ "GWS",
-    team == "Suns" ~ "Gold Coast",
-    team == "Bombers" ~ "Essendon",
-    team == "Swans" ~ "Sydney",
-    team == "Magpies" ~ "Collingwood",
-    team == "Crows" ~ "Adelaide",
-    team == "Bulldogs" ~ "Footscray",
-    team == "Dockers" ~ "Fremantle",
-    team == "Power" ~ "Port Adelaide",
-    team == "Saints" ~ "St Kilda",
-    team == "Eagles" ~ "West Coast",
-    team == "Cats" ~ "Geelong",
-    team == "Hawks" ~ "Hawthorn",
+    # keeping this one so that it's the same behaviour for University Blues:
+    team == "Blues" ~ "Carlton", 
+    
+    # simplifying the coercing of team names
+    stringr::str_detect(tolower(team), "crows") ~ "Adelaide",
+    stringr::str_detect(tolower(team), "brisbane|lions|bears") ~ "Brisbane Lions",
+    stringr::str_detect(tolower(team), "carlton") ~ "Carlton", # this allows us to coerce any occurrence of 'Carlton Blues' to 'Carlton'
+    stringr::str_detect(tolower(team), "magpies|pies") ~ "Collingwood",
+    stringr::str_detect(tolower(team), "bombers") ~ "Essendon",
+    stringr::str_detect(tolower(team), "bulldog") ~ "Footscray",
+    stringr::str_detect(tolower(team), "docker") ~ "Fremantle",
+    stringr::str_detect(tolower(team), "gw syd|gws|greater western|giants") ~ "GWS",
+    stringr::str_detect(tolower(team), "cats") ~ "Geelong",
+    stringr::str_detect(tolower(team), "gc|suns") ~ "Gold Coast",
+    stringr::str_detect(tolower(team), "hawks") ~ "Hawthorn",
+    stringr::str_detect(tolower(team), "demons") ~ "Melbourne",
+    stringr::str_detect(tolower(team), "kangaroos") ~ "North Melbourne",
+    stringr::str_detect(tolower(team), "power") ~ "Port Adelaide",
+    stringr::str_detect(tolower(team), "tigers") ~ "Richmond",
+    stringr::str_detect(tolower(team), "stk|saints") ~ "St Kilda",
+    stringr::str_detect(tolower(team), "swans|south melbourne") ~ "Sydney",
+    stringr::str_detect(tolower(team), "wce|eagles") ~ "West Coast",
+    
+    # AFL have also introduced capitalised team names for GC and GWS
+    stringr::str_detect(team, "SUNS") ~ "Gold Coast",
+    stringr::str_detect(team, "GIANTS") ~ "GWS",
+    
+    # handle for indigenous round team names
+    team == "Narrm" ~ "Melbourne",
+    team == "Walyalup" ~ "Fremantle",
+    team == "Yartapuulti" ~ "Port Adelaide",
+    team == "Euro-Yroke" ~ "St Kilda",
+    team == "Kuwarna" ~ "Adelaide",
+    team == "Waalitj Marawar" ~ "West Coast",
     TRUE ~ team
   )
 }


### PR DESCRIPTION
Local check produced two failed tests that have nothing to do with the changes proposed in this PR:

```
══ Failed tests ════════════════════════════════════════════════════════════════
── Error ('test-fetch-betting-odds.R:30:5'): fetch_betting_odds_footywire: works with different inputs  ──
<purrr_error_indexed/rlang_error/error/condition>
Error in `purrr::map(., fetch_betting_odds_page)`: i In index: 1.
Caused by error in `open.connection()`:
! Timeout was reached: [www.footywire.com] SSL connection timeout
Backtrace:
     ▆
  1. ├─... %>% suppressWarnings() at test-fetch-betting-odds.R:30:4
  2. ├─base::suppressWarnings(.)
  3. │ └─base::withCallingHandlers(...)
  4. ├─testthat::expect_warning(.)
  5. │ └─testthat:::expect_condition_matching(...)
  6. │   └─testthat:::quasi_capture(...)
  7. │     ├─testthat (local) .capture(...)
  8. │     │ └─base::withCallingHandlers(...)
  9. │     └─rlang::eval_bare(quo_get_expr(.quo), quo_get_env(.quo))
 10. ├─fitzRoy::fetch_betting_odds_footywire(...)
 11. │ └─... %>% purrr::map(convert_to_data_frame)
 12. ├─purrr::map(., convert_to_data_frame)
 13. │ └─purrr:::map_("list", .x, .f, ..., .progress = .progress)
 14. │   └─purrr:::vctrs_vec_compat(.x, .purrr_user_env)
 15. ├─purrr::map(., ~do.call(extract_table_rows, .))
 16. │ └─purrr:::map_("list", .x, .f, ..., .progress = .progress)
 17. │   └─purrr:::vctrs_vec_compat(.x, .purrr_user_env)
 18. ├─purrr::map(., fetch_betting_odds_page)
 19. │ └─purrr:::map_("list", .x, .f, ..., .progress = .progress)
 20. │   ├─purrr:::with_indexed_errors(...)
 21. │   │ └─base::withCallingHandlers(...)
 22. │   ├─purrr:::call_with_cleanup(...)
 23. │   └─fitzRoy (local) .f(.x[[i]], ...)
 24. │     └─... %>% list(., season)
 25. ├─xml2::read_html(.)
 26. ├─xml2:::read_html.default(.)
 27. │ ├─base::suppressWarnings(...)
 28. │ │ └─base::withCallingHandlers(...)
 29. │ ├─xml2::read_xml(x, encoding = encoding, ..., as_html = TRUE, options = options)
 30. │ └─xml2:::read_xml.character(...)
 31. │   └─xml2:::read_xml.connection(...)
 32. │     ├─base::open(x, "rb")
 33. │     └─base::open.connection(x, "rb")
 34. └─base::.handleSimpleError(...)
 35.   └─purrr (local) h(simpleError(msg, call))
 36.     └─cli::cli_abort(...)
 37.       └─rlang::abort(...)
── Error ('test-fetch-betting-odds.R:137:3'): round numbers don't increment across bye weeks without matches ──
Error in `open.connection(x, "rb")`: Timeout was reached: [www.footywire.com] SSL connection timeout
Backtrace:
     ▆
  1. ├─testthat::expect_warning(...) at test-fetch-betting-odds.R:137:2
  2. │ └─testthat:::expect_condition_matching(...)
  3. │   └─testthat:::quasi_capture(...)
  4. │     ├─testthat (local) .capture(...)
  5. │     │ └─base::withCallingHandlers(...)
  6. │     └─rlang::eval_bare(quo_get_expr(.quo), quo_get_env(.quo))
  7. ├─fitzRoy:::get_footywire_betting_odds(2019, 2020)
  8. │ └─fitzRoy::fetch_betting_odds_footywire(...)
  9. │   └─fitzRoy (local) fetch_valid_seasons()
 10. │     └─fitzRoy (local) fetch_betting_odds_page(2010)
 11. │       └─... %>% list(., season)
 12. ├─xml2::read_html(.)
 13. └─xml2:::read_html.default(.)
 14.   ├─base::suppressWarnings(...)
 15.   │ └─base::withCallingHandlers(...)
 16.   ├─xml2::read_xml(x, encoding = encoding, ..., as_html = TRUE, options = options)
 17.   └─xml2:::read_xml.character(...)
 18.     └─xml2:::read_xml.connection(...)
 19.       ├─base::open(x, "rb")
 20.       └─base::open.connection(x, "rb")
```