### PR TITLE
address misspelling of Wallitj Marawar #259

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 ## Bug Fixes
 
 * Fix duplicates for most recent game in `fetch_player_stats_afltables()` ([#250](https://github.com/jimmyday12/fitzRoy/issues/250))
+* Addresses new afl.com.au spelling of *Wallitj Marawar* in `replace_teams()` ([#259](https://github.com/jimmyday12/fitzRoy/issues/259))
 
 # fitzRoy 1.6.0
 

--- a/R/helpers-afltables.R
+++ b/R/helpers-afltables.R
@@ -71,6 +71,7 @@ replace_teams <- function(team) {
     team == "Euro-Yroke" ~ "St Kilda",
     team == "Kuwarna" ~ "Adelaide",
     team == "Waalitj Marawar" ~ "West Coast",
+    team == "Wallitj Marawar" ~ "West Coast",
     TRUE ~ team
   )
 }


### PR DESCRIPTION
This was a simple one-line addition to address the AFL's different spelling of Wallitj Marawar for West Coast this season. Looks as though this is an error in their API results as their website reflects correct spelling.

I ran `devtools::check()` locally and got failures, however on closer inspection the failures were due to the Indigenous round team name's not being included in the `team_check_()` functions.

Let me know if there's anything else you need me to do for this PR @jimmyday12.

Thanks