### PR TITLE
Repoint cached data reads from .rda to Parquet release

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -25,3 +25,5 @@ create_package.R
 ^NEWS.md$
 ^pkgdown$
 ^CRAN-SUBMISSION$
+^\.claude$
+^PHASE2_BRIEF\.md$

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ docs
 .DS_Store
 /doc/
 /Meta/
+PHASE2_BRIEF.md
+.claude/

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -55,7 +55,8 @@ Imports:
     cli,
     lifecycle,
     httr2,
-    janitor
+    janitor,
+    nanoparquet
 Suggests:
     covr,
     elo,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # fitzRoy (development version)
 
+* `fetch_player_stats_afltables()` and `fetch_player_stats_footywire()` now read
+  canonical Parquet files from the `fitzroy_data` release instead of legacy `.rda`
+  files. This is faster and more reliable. Returned data is unchanged.
+* Added `nanoparquet` to Imports for lightweight Parquet reading.
+
 # fitzRoy 1.7.0
 
 ## New Features

--- a/R/fetch-player-stats.R
+++ b/R/fetch-player-stats.R
@@ -170,16 +170,14 @@ fetch_player_stats_afltables <- function(season = NULL,
 
 
   # nolint start
-  dat_url <- url("https://github.com/jimmyday12/fitzRoy_data/raw/main/data-raw/afl_tables_playerstats/afldata.rda")
+  dat_url <- "https://github.com/jimmyday12/fitzroy_data/releases/download/data/afltables_player_stats.parquet"
   # nolint end
 
-  load_r_data <- function(fname) {
-    load(fname)
-    get(ls()[ls() != "fname"])
-  }
-
   cli::cli_progress_step("Fetching cached data from {.url github.com/jimmyday12/fitzRoy_data}")
-  dat <- load_r_data(dat_url)
+  tmp <- tempfile(fileext = ".parquet")
+  utils::download.file(dat_url, tmp, quiet = TRUE, mode = "wb")
+  dat <- nanoparquet::read_parquet(tmp)
+  unlink(tmp)
 
   if (rescrape) {
     if (is.null(rescrape_start_season)) rescrape_start_season <- format(start_date, "%Y")
@@ -330,18 +328,12 @@ fetch_player_stats_footywire <- function(season = NULL, round_number = NULL, che
     url <- "https://github.com/jimmyday12/fitzRoy_data"
     cli::cli_progress_step("Checking data on {.url {url}}")
 
-    dat_url2 <- "https://github.com/jimmyday12/fitzroy_data/raw/main/data-raw/player_stats/player_stats.rda" # nolint
+    dat_url2 <- "https://github.com/jimmyday12/fitzroy_data/releases/download/data/footywire_player_stats.parquet" # nolint
 
-    load_r_data <- function(fname) {
-      tmp <- tempfile(fileext = ".rda")
-      utils::download.file(fname, tmp, quiet = TRUE)
-
-      load(tmp)
-      unlink(tmp)
-      get(ls()[!ls() %in% c("tmp", "fname")])
-    }
-
-    dat_git <- load_r_data(dat_url2)
+    tmp <- tempfile(fileext = ".parquet")
+    utils::download.file(dat_url2, tmp, quiet = TRUE, mode = "wb")
+    dat_git <- nanoparquet::read_parquet(tmp)
+    unlink(tmp)
 
     dat_git <- dat_git %>%
       dplyr::filter(.data$Season >= min(season) & .data$Season <= max(season))

--- a/tests/testthat/_snaps/fetch-player-stats.md
+++ b/tests/testthat/_snaps/fetch-player-stats.md
@@ -1,0 +1,148 @@
+# fetch_player_stats_afltables returns expected column names and types
+
+    Code
+      col_names
+    Output
+       [1] "Season"                  "Round"                  
+       [3] "Date"                    "Local.start.time"       
+       [5] "Venue"                   "Attendance"             
+       [7] "First.name"              "Surname"                
+       [9] "ID"                      "Jumper.No."             
+      [11] "Playing.for"             "Kicks"                  
+      [13] "Marks"                   "Handballs"              
+      [15] "Disposals"               "Goals"                  
+      [17] "Behinds"                 "Hit.Outs"               
+      [19] "Tackles"                 "Rebounds"               
+      [21] "Inside.50s"              "Clearances"             
+      [23] "Clangers"                "Frees.For"              
+      [25] "Frees.Against"           "Brownlow.Votes"         
+      [27] "Contested.Possessions"   "Uncontested.Possessions"
+      [29] "Contested.Marks"         "Marks.Inside.50"        
+      [31] "One.Percenters"          "Bounces"                
+      [33] "Goal.Assists"            "Time.on.Ground"         
+      [35] "Substitute"              "Umpire.1"               
+      [37] "Umpire.2"                "Umpire.3"               
+      [39] "Umpire.4"                "Home.team"              
+      [41] "HQ1G"                    "HQ1B"                   
+      [43] "HQ2G"                    "HQ2B"                   
+      [45] "HQ3G"                    "HQ3B"                   
+      [47] "HQ4G"                    "HQ4B"                   
+      [49] "HQETG"                   "HQETB"                  
+      [51] "Home.score"              "Away.team"              
+      [53] "AQ1G"                    "AQ1B"                   
+      [55] "AQ2G"                    "AQ2B"                   
+      [57] "AQ3G"                    "AQ3B"                   
+      [59] "AQ4G"                    "AQ4B"                   
+      [61] "AQETG"                   "AQETB"                  
+      [63] "Away.score"              "HQ1P"                   
+      [65] "HQ2P"                    "HQ3P"                   
+      [67] "HQ4P"                    "HQETP"                  
+      [69] "AQ1P"                    "AQ2P"                   
+      [71] "AQ3P"                    "AQ4P"                   
+      [73] "AQETP"                   "Player"                 
+      [75] "Team"                    "url"                    
+      [77] "Age"                     "Career.Games"           
+      [79] "Coach"                   "DOB"                    
+      [81] "Home.Away"              
+
+---
+
+    Code
+      col_classes
+    Output
+                       Season                   Round                    Date 
+                    "integer"             "character"                  "Date" 
+             Local.start.time                   Venue              Attendance 
+                    "integer"             "character"               "integer" 
+                   First.name                 Surname                      ID 
+                  "character"             "character"               "integer" 
+                   Jumper.No.             Playing.for                   Kicks 
+                  "character"             "character"               "integer" 
+                        Marks               Handballs               Disposals 
+                    "integer"               "integer"               "integer" 
+                        Goals                 Behinds                Hit.Outs 
+                    "integer"               "integer"               "integer" 
+                      Tackles                Rebounds              Inside.50s 
+                    "integer"               "integer"               "integer" 
+                   Clearances                Clangers               Frees.For 
+                    "integer"               "integer"               "integer" 
+                Frees.Against          Brownlow.Votes   Contested.Possessions 
+                    "integer"               "integer"               "integer" 
+      Uncontested.Possessions         Contested.Marks         Marks.Inside.50 
+                    "integer"               "integer"               "integer" 
+               One.Percenters                 Bounces            Goal.Assists 
+                    "integer"               "integer"               "integer" 
+               Time.on.Ground              Substitute                Umpire.1 
+                    "integer"             "character"             "character" 
+                     Umpire.2                Umpire.3                Umpire.4 
+                  "character"             "character"             "character" 
+                    Home.team                    HQ1G                    HQ1B 
+                  "character"               "integer"               "integer" 
+                         HQ2G                    HQ2B                    HQ3G 
+                    "integer"               "integer"               "integer" 
+                         HQ3B                    HQ4G                    HQ4B 
+                    "integer"               "integer"               "integer" 
+                        HQETG                   HQETB              Home.score 
+                    "integer"               "integer"               "integer" 
+                    Away.team                    AQ1G                    AQ1B 
+                  "character"               "integer"               "integer" 
+                         AQ2G                    AQ2B                    AQ3G 
+                    "integer"               "integer"               "integer" 
+                         AQ3B                    AQ4G                    AQ4B 
+                    "integer"               "integer"               "integer" 
+                        AQETG                   AQETB              Away.score 
+                    "integer"               "integer"               "integer" 
+                         HQ1P                    HQ2P                    HQ3P 
+                    "integer"               "integer"               "integer" 
+                         HQ4P                   HQETP                    AQ1P 
+                    "integer"               "integer"               "integer" 
+                         AQ2P                    AQ3P                    AQ4P 
+                    "integer"               "integer"               "integer" 
+                        AQETP                  Player                    Team 
+                    "integer"             "character"             "character" 
+                          url                     Age            Career.Games 
+                  "character"               "numeric"               "integer" 
+                        Coach                     DOB               Home.Away 
+                  "character"             "character"             "character" 
+
+# fetch_player_stats_footywire returns expected column names and types
+
+    Code
+      col_names
+    Output
+       [1] "Date"           "Season"         "Round"          "Venue"         
+       [5] "Player"         "Team"           "Opposition"     "Status"        
+       [9] "Match_id"       "GA"             "CP"             "UP"            
+      [13] "ED"             "DE"             "CM"             "MI5"           
+      [17] "One.Percenters" "BO"             "TOG"            "K"             
+      [21] "HB"             "D"              "M"              "G"             
+      [25] "B"              "T"              "HO"             "I50"           
+      [29] "CL"             "CG"             "R50"            "FF"            
+      [33] "FA"             "AF"             "SC"             "CCL"           
+      [37] "SCL"            "SI"             "MG"             "TO"            
+      [41] "ITC"            "T5"            
+
+---
+
+    Code
+      col_classes
+    Output
+                Date         Season          Round          Venue         Player 
+              "Date"      "numeric"    "character"    "character"    "character" 
+                Team     Opposition         Status       Match_id             GA 
+         "character"    "character"    "character"      "numeric"      "numeric" 
+                  CP             UP             ED             DE             CM 
+           "numeric"      "numeric"      "numeric"      "numeric"      "numeric" 
+                 MI5 One.Percenters             BO            TOG              K 
+           "numeric"      "numeric"      "numeric"      "numeric"      "numeric" 
+                  HB              D              M              G              B 
+           "numeric"      "numeric"      "numeric"      "numeric"      "numeric" 
+                   T             HO            I50             CL             CG 
+           "numeric"      "numeric"      "numeric"      "numeric"      "numeric" 
+                 R50             FF             FA             AF             SC 
+           "numeric"      "numeric"      "numeric"      "numeric"      "numeric" 
+                 CCL            SCL             SI             MG             TO 
+           "numeric"      "numeric"      "numeric"      "numeric"      "numeric" 
+                 ITC             T5 
+           "numeric"      "numeric" 
+

--- a/tests/testthat/test-fetch-player-stats.R
+++ b/tests/testthat/test-fetch-player-stats.R
@@ -123,6 +123,30 @@ test_that("fetch_player_stats works", {
 })
 
 
+test_that("fetch_player_stats_afltables returns expected column names and types", {
+  testthat::skip_if_offline()
+  testthat::skip_on_cran()
+
+  dat <- fetch_player_stats_afltables(season = 2020)
+  col_names <- names(dat)
+  col_classes <- vapply(dat, function(x) class(x)[[1L]], character(1L))
+
+  expect_snapshot(col_names)
+  expect_snapshot(col_classes)
+})
+
+test_that("fetch_player_stats_footywire returns expected column names and types", {
+  testthat::skip_if_offline()
+  testthat::skip_on_cran()
+
+  dat <- fetch_player_stats_footywire(season = 2020)
+  col_names <- names(dat)
+  col_classes <- vapply(dat, function(x) class(x)[[1L]], character(1L))
+
+  expect_snapshot(col_names)
+  expect_snapshot(col_classes)
+})
+
 test_that("fetch_player_stats works for non-AFL leagues", {
   testthat::skip_if_offline()
   testthat::skip_on_cran()


### PR DESCRIPTION
## Summary

- `fetch_player_stats_afltables()` and `fetch_player_stats_footywire()` now read canonical Parquet files from the `fitzroy_data` `data` release instead of legacy `.rda` files from the repo tree
- Adds `nanoparquet` to Imports — lightweight, zero-compiled-dependency Parquet reader
- Adds snapshot tests pinning column names and per-column classes for both repointed functions (season 2020)

## What changed

The two big cached-data reads were the last pieces pointing at raw git blobs. This PR swaps them to the release assets published by Phase 1 of the data pipeline migration:

| Function | Old source | New source |
|---|---|---|
| `fetch_player_stats_afltables` | `fitzRoy_data/data-raw/.../afldata.rda` | `fitzroy_data/releases/download/data/afltables_player_stats.parquet` |
| `fetch_player_stats_footywire` | `fitzroy_data/data-raw/.../player_stats.rda` | `fitzroy_data/releases/download/data/footywire_player_stats.parquet` |

**No change to returned data** — same columns, same types. The `Jumper.No.`/`Substitute` character coercions and all scrape-recent top-up logic are untouched.

The two CSV id reads (`player_ids.csv`, `player_mapping_afltables.csv`) are left as-is per the brief.

## What's NOT changed
- Function signatures
- Returned tibble shape (column names and types)
- Scrape-recent / `check_existing` top-up logic
- The two CSV id reads

## Test plan
- [x] Existing test suite passes (all `test-fetch-player-stats.R` tests)
- [x] New snapshot tests pin column names + per-column classes for both functions
- [x] `R CMD check` clean (only pre-existing vignette warnings)
- [x] `waldo::compare` old-vs-new output over a fixed season (manual validation before merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)