### PR TITLE
Fix CRAN check ERROR from top-level network call in tests

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -27,3 +27,4 @@ create_package.R
 ^CRAN-SUBMISSION$
 ^\.claude$
 ^PHASE2_BRIEF\.md$
+^\.git$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: fitzRoy
 Title: Easily Scrape and Process AFL Data
-Version: 1.7.0.9000
+Version: 1.8.0
 Authors@R:
     c(person(given = "James",
              family = "Day",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,15 @@
-# fitzRoy (development version)
+# fitzRoy 1.8.0
 
+* Fixed an `R CMD check` ERROR on CRAN's machines. `test-fetch-player-stats.R`
+  called `fetch_results_afltables()` at the top level of the file to work out the
+  current season. Top-level test code runs before the `skip_on_cran()` /
+  `skip_if_offline()` guards inside the `test_that()` blocks, so this made a
+  network request on check machines with no internet access and failed the whole
+  file with "cannot open the connection". The season is now resolved lazily from
+  inside the tests, after the skips.
+* `fetch_results_afltables()` now fails gracefully with an informative message
+  naming the resource when afltables.com cannot be reached, instead of surfacing
+  readr's bare "cannot open the connection" error.
 * `fetch_player_stats_afltables()` and `fetch_player_stats_footywire()` now read
   canonical Parquet files from the `fitzroy_data` release instead of legacy `.rda`
   files. This is faster and more reliable. Returned data is unchanged.

--- a/R/fetch-results.R
+++ b/R/fetch-results.R
@@ -133,7 +133,7 @@ fetch_results_afltables <- function(season = NULL, round_number = NULL) {
     Venue = NA
   )
 
-  match_data <- readr::read_fwf(url_text,
+  match_data <- read_fwf_fitzroy(url_text,
     skip = 2,
     col_positions = cols,
     col_types = c("dcccccccc")

--- a/R/utils-http.R
+++ b/R/utils-http.R
@@ -42,3 +42,35 @@ read_html_fitzroy <- function(url) {
 fitzroy_ua <- function() {
   httr::user_agent(fitzroy_user_agent())
 }
+
+#' Read a fixed-width file from a URL, failing gracefully
+#'
+#' Wraps [readr::read_fwf()] so that a network-level failure (host
+#' unreachable, no internet, timeout, non-2xx response) produces an
+#' informative message naming the resource rather than readr's bare
+#' "cannot open the connection", as required by CRAN policy for packages
+#' using internet resources.
+#'
+#' @param url A URL to read.
+#' @param ... Passed through to [readr::read_fwf()].
+#' @keywords internal
+#' @noRd
+read_fwf_fitzroy <- function(url, ...) {
+  old_ua <- getOption("HTTPUserAgent")
+  options(HTTPUserAgent = fitzroy_user_agent())
+  on.exit(options(HTTPUserAgent = old_ua), add = TRUE)
+
+  tryCatch(
+    readr::read_fwf(url, ...),
+    error = function(e) {
+      cli::cli_abort(
+        c(
+          "Could not read data from {.url {url}}.",
+          "i" = "The site may be unavailable, or you may not have an internet connection.",
+          "x" = conditionMessage(e)
+        ),
+        call = NULL
+      )
+    }
+  )
+}

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,13 +1,33 @@
+## Resubmission
+
+This release fixes the ERROR shown on
+<https://cran.r-project.org/web/checks/check_results_fitzRoy.html> for
+r-devel-linux-x86_64-fedora-gcc, as requested by the CRAN team on 2026-08-14.
+
+The cause was test code, not package code. `tests/testthat/test-fetch-player-stats.R`
+computed the current season at the *top level* of the test file by calling
+`fetch_results_afltables()`. Top-level code in a test file runs before the
+`testthat::skip_on_cran()` and `testthat::skip_if_offline()` guards inside the
+`test_that()` blocks, so the internet resource was contacted unconditionally on
+check machines without network access, and the file failed with
+"cannot open the connection".
+
+The season is now resolved lazily from inside the tests, after the skip guards,
+so no network access occurs on CRAN. All tests in the package are now correctly
+guarded by `skip_on_cran()`/`skip_if_offline()`.
+
+In addition, and in line with the policy quoted in your message,
+`fetch_results_afltables()` now fails gracefully with an informative message
+naming the unavailable resource rather than propagating readr's bare
+"cannot open the connection" error.
+
 ## R CMD check results
 
-0 errors | 0 warnings | 1 note
+0 errors | 0 warnings | 0 notes
 
-* checking CRAN incoming feasibility ... NOTE
-  - Found the following (possibly) invalid URLs for https://www.footywire.com
-    (Status: 406, Not Acceptable): this URL is correct and functional in a
-    browser. The 406 status is returned because the server rejects automated
-    requests without a browser-like User-Agent header. The site is a primary
-    data source for the package.
+`urlchecker::url_check()` is clean. The footywire.com URL NOTE reported against
+earlier versions no longer occurs, as fitzRoy now sends a descriptive
+User-Agent rather than R's generic default.
 
 ## Test environments
 
@@ -17,13 +37,7 @@
 * GitHub Actions: Ubuntu (latest), R devel
 * GitHub Actions: Ubuntu (latest), R release
 * GitHub Actions: Ubuntu (latest), R oldrel-1
-* Windows Server 2022, R-devel (win-builder), 2026-03-12
 
-## Downstream Dependancies
+## Downstream Dependencies
 
 There are currently no downstream dependencies for this package
-
-
-
-
-

--- a/tests/testthat/test-fetch-player-stats.R
+++ b/tests/testthat/test-fetch-player-stats.R
@@ -1,12 +1,30 @@
-# get most recent season
-current_year <- Sys.Date() %>%
-  format("%Y") %>%
-  as.numeric()
-x <- fetch_results_afltables(current_year)
-if (nrow(x) == 0) {
-  seas <- current_year - 1
-} else {
-  seas <- current_year
+# Determine the most recent season that has afltables results.
+#
+# This *must not* run at file load time - top-level code in a test file runs
+# before any `skip_on_cran()`/`skip_if_offline()` inside a `test_that()` block,
+# so a network call here errors out the whole file on CRAN's check machines
+# (which have no internet access) regardless of the skips below. Instead it is
+# called lazily from inside each test that needs it, after the skips, and the
+# result is cached for the remainder of the file's run.
+.seas_cache <- NULL
+
+latest_afltables_season <- function() {
+  if (!is.null(.seas_cache)) {
+    return(.seas_cache)
+  }
+
+  current_year <- as.numeric(format(Sys.Date(), "%Y"))
+
+  x <- tryCatch(
+    fetch_results_afltables(current_year),
+    error = function(e) {
+      testthat::skip(paste0("afltables results unavailable: ", conditionMessage(e)))
+    }
+  )
+
+  seas <- if (nrow(x) == 0) current_year - 1 else current_year
+  .seas_cache <<- seas
+  seas
 }
 
 
@@ -14,7 +32,7 @@ test_that("fetch_player_stats_afltables works for various inputs", {
   testthat::skip_if_offline()
   testthat::skip_on_cran()
 
-
+  seas <- latest_afltables_season()
 
   # test normal function
   dat <- fetch_player_stats_afltables(seas)


### PR DESCRIPTION
Fixes the ERROR on `r-devel-linux-x86_64-fedora-gcc` reported in the CRAN maintainer notice of 2026-08-14 (correction deadline **2026-08-28**).

Refs #289.

## Root cause

`tests/testthat/test-fetch-player-stats.R` computed the current season at the **top level** of the file:

```r
x <- fetch_results_afltables(current_year)
```

Top-level code in a testthat file runs *before* the `skip_on_cran()` / `skip_if_offline()` guards inside the `test_that()` blocks. So the request was made unconditionally on check machines with no network access, and `readr::read_fwf()` failed the whole file with `cannot open the connection`.

This was latent on every flavour, not specific to Fedora — the other machines simply happened to have working network access when they ran.

## Changes

- **The fix.** The season is resolved lazily via `latest_afltables_season()`, called from inside the test after the skips and cached for the rest of the file's run. A network failure there becomes a `skip()` rather than an error.
- **Graceful failure.** Per the policy quoted in the CRAN notice, added `read_fwf_fitzroy()` alongside the existing `read_html_fitzroy()` helper, so `fetch_results_afltables()` reports the unavailable resource by name instead of surfacing readr's bare error.
- **Release prep for 1.8.0.** Version bump, NEWS entry, and `cran-comments.md` refreshed — the footywire 406 URL NOTE no longer occurs now that fitzRoy sends a descriptive User-Agent, so the comments claimed a NOTE that no longer happens.
- **`.Rbuildignore`.** In a git worktree `.git` is a pointer *file*, not a directory, so `R CMD build` does not auto-exclude it and it was being packaged, triggering a hidden-files NOTE. Harmless in a normal clone.

## Verification

- Full suite under `NOT_CRAN=false` on the installed package: **FAIL 0 | ERROR 0 | SKIP 86 | PASS 52**. CRAN's run was `FAIL 1 | SKIP 83 | PASS 52` — same pass count, error gone.
- `devtools::check(manual = TRUE, remote = TRUE, env_vars = c(NOT_CRAN = "false"))`: **0 errors, 0 warnings**; vignettes, PDF manual, examples and tests all OK.
- `urlchecker::url_check()`: all 109 URLs correct.
- Confirmed the lazy helper still resolves to `2026`, identical to the old top-level logic.
- Scanned every other test file — this was the only one with top-level network code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)