### PR TITLE
Stop calling deprecated get_aflw_cookie() internally (part 1 of #291)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # fitzRoy 1.8.0
 
+* `get_aflw_detailed_data()` no longer emits a deprecation warning naming
+  `get_aflw_cookie()`, a function callers never invoked and cannot reach through
+  the public API. It (and the internal `fetch_match_stats_afl()`) now call
+  `get_afl_cookie()` directly. `get_aflw_cookie()` remains deprecated and
+  unchanged for anyone calling it themselves
+  ([#291](https://github.com/jimmyday12/fitzRoy/issues/291)).
 * Fixed an `R CMD check` ERROR on CRAN's machines. `test-fetch-player-stats.R`
   called `fetch_results_afltables()` at the top level of the file to work out the
   current season. Top-level test code runs before the `skip_on_cran()` /

--- a/R/helpers-afl.R
+++ b/R/helpers-afl.R
@@ -578,7 +578,7 @@ fetch_match_roster_afl <- function(id, cookie = NULL) {
 #' @keywords internal
 #' @noRd
 fetch_match_stats_afl <- function(id, cookie = NULL) {
-  if (is.null(cookie)) cookie <- get_aflw_cookie()
+  if (is.null(cookie)) cookie <- get_afl_cookie()
 
   api <- httr::modify_url(
     url = "https://api.afl.com.au",

--- a/R/womens_stats.R
+++ b/R/womens_stats.R
@@ -10,7 +10,7 @@
 #' \dontrun{
 #' get_aflw_cookie()
 #' # ->
-#' get_aflw_cookie()
+#' get_afl_cookie()
 #' }
 #' @keywords internal
 get_aflw_cookie <- function() {
@@ -231,7 +231,7 @@ get_aflw_match_data <- function(start_year = 2017) {
 #' get_aflw_detailed_data(c("CD_M20172640101", "CD_M20172640102"))
 #' }
 get_aflw_detailed_data <- function(matchids) {
-  cookie <- get_aflw_cookie()
+  cookie <- get_afl_cookie()
   # Round and competition IDs can be inferred from match Ids:
   # Match ID:       "CD_M20172640101"
   # Round ID:       "CD_R201726401"     M->R, last two characters removed

--- a/R/z_score-progression.R
+++ b/R/z_score-progression.R
@@ -8,9 +8,7 @@
 #' @examples
 #' #
 #' \dontrun{
-#' get_match_results()
-#' # ->
-#' fetch_results_afltables()
+#' get_score_progression_raw()
 #' }
 get_score_progression_raw <- function() {
   lifecycle::deprecate_stop(

--- a/man/get_aflw_cookie.Rd
+++ b/man/get_aflw_cookie.Rd
@@ -16,7 +16,7 @@ Replaced with a standard function to return cookies for either mens or womens da
 \dontrun{
 get_aflw_cookie()
 # ->
-get_aflw_cookie()
+get_afl_cookie()
 }
 }
 \keyword{internal}

--- a/man/get_score_progression_raw.Rd
+++ b/man/get_score_progression_raw.Rd
@@ -14,8 +14,6 @@ This function has been deprecated due to its inefficiency
 \examples{
 #
 \dontrun{
-get_match_results()
-# ->
-fetch_results_afltables()
+get_score_progression_raw()
 }
 }


### PR DESCRIPTION
Fixes part 1 of https://github.com/jimmyday12/fitzRoy/issues/291.

## The bug

`get_aflw_cookie()` has been deprecated since 1.0.0 (`lifecycle::deprecate_warn`) and is a one-line passthrough to `get_afl_cookie()`. fitzRoy was still calling it internally in two places:

| Call site | Caller | Exported? |
|---|---|---|
| `R/womens_stats.R:234` | `get_aflw_detailed_data()` | **yes** (NAMESPACE:44) |
| `R/helpers-afl.R:581` | `fetch_match_stats_afl()` | no |

The first one is the user-visible bug: calling the current, supported, exported `get_aflw_detailed_data()` emitted a deprecation warning naming `get_aflw_cookie()` — a function the caller never invoked and cannot reach through the public API.

## The fix

Both call sites now call `get_afl_cookie()` directly. **No behaviour change** — the deprecated function only forwarded. `get_aflw_cookie()` itself is untouched and stays deprecated for anyone calling it directly.

Two roxygen bugs found alongside are fixed too:

- `get_aflw_cookie()`'s migration example showed `get_aflw_cookie()` on **both** sides of the `# ->` arrow; the right-hand side is now `get_afl_cookie()`.
- `get_score_progression_raw()`'s example was a copy-paste of `get_match_results()` -> `fetch_results_afltables()`, belonging to a different function; it now describes `get_score_progression_raw()`.

Re-documented with `devtools::document()`; NEWS.md bullet added under 1.8.0.

## Verification

- Audited all 16 deprecated functions in the namespace by walking each function body: **no non-deprecated function calls a deprecated one any more.**
- `devtools::test()` — `FAIL 0 | WARN 63 | SKIP 1 | PASS 498`.
- `devtools::check_man()` — no issues detected.

## Out of scope

Part 2 of #291 (advancing the 15 `deprecate_warn()` calls to `deprecate_stop()` and removing `get_score_progression_raw()`) is deliberately **not** included. That is a breaking change affecting 41 assertions across 7 test files and belongs in a later release.

Does not touch #290.

🤖 Generated with [Claude Code](https://claude.com/claude-code)