### PR TITLE
Make network-dependent tests resilient to source outages (#292)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,22 @@
 # fitzRoy 1.8.0
 
+* Made the test suite resilient to a data source being briefly unreachable
+  ([#292](https://github.com/jimmyday12/fitzRoy/issues/292)). `R CMD check` on CI
+  was failing most runs because afltables.com or footywire.com timed out from a
+  GitHub runner mid-run, which is a network blip rather than a code defect. The
+  footywire-only test helpers are now source-agnostic
+  (`tests/testthat/helper-network.R`) and applied to the afltables tests too, so
+  a network failure skips the affected test instead of failing the build - and
+  the resulting skip now names the source that actually failed rather than
+  always blaming footywire.
+* `get_afltables_urls()` and `get_afltables_player_ids()` now fail gracefully
+  when afltables.com cannot be reached, returning an empty result / the stored
+  player ids with an informative warning, instead of surfacing a confusing
+  ``Must supply `.init` when `.x` is empty`` or `subscript out of bounds` error
+  from downstream code.
+* `get_afltables_player_ids()` now reports an informative message naming the
+  resource when the cached player id file cannot be read, instead of readr's
+  bare "cannot open the connection".
 * Fixed an `R CMD check` ERROR on CRAN's machines. `test-fetch-player-stats.R`
   called `fetch_results_afltables()` at the top level of the file to work out the
   current season. Top-level test code runs before the `skip_on_cran()` /

--- a/R/helpers-afltables-playerstats.R
+++ b/R/helpers-afltables-playerstats.R
@@ -339,6 +339,18 @@ get_afltables_urls <- function(start_date,
 
   html_games <- Filter(Negate(is.null), html_games)
 
+  # url_works() swallows per-season errors so a single bad season doesn't
+  # sink the lot - but if afltables.com is unreachable every season drops
+  # out, and the purrr::reduce() below would then fail with a cryptic
+  # "Must supply `.init` when `.x` is empty". Fail gracefully instead.
+  if (length(html_games) == 0) {
+    cli::cli_warn(c(
+      "Could not read any season pages from {.url https://afltables.com/afl/seas/}.",
+      "i" = "The site may be unavailable, or you may not have an internet connection."
+    ))
+    return(character(0))
+  }
+
   dates <- html_games %>%
     purrr::map(
       rvest::html_nodes,
@@ -360,7 +372,7 @@ get_afltables_urls <- function(start_date,
   # Return only id's that match
   match_ids <- match_ids %>%
     purrr::map2(.y = dates, ~ magrittr::extract(.x, .y)) %>%
-    purrr::reduce(c)
+    purrr::reduce(c, .init = character(0))
 
   match_ids[!is.na(match_ids)]
 }
@@ -471,7 +483,7 @@ get_afltables_player_ids <- function(seasons) {
   col_vars <- c("Season", "Player", "ID", "Team")
 
   ids_old <- git_url %>%
-    readr::read_csv(col_types = c("dcdc")) %>%
+    read_csv_fitzroy(col_types = c("dcdc")) %>%
     dplyr::mutate(ID = as.integer(.data$ID)) %>%
     dplyr::select(!!col_vars) %>%
     dplyr::distinct()
@@ -568,43 +580,57 @@ get_afltables_player_ids <- function(seasons) {
     purrr::discard(~ nrow(.x) == 0)
 
 
-  # Some DFs have numeric columns as 'chr' and some have them as 'dbl',
-  # so we need to make them consistent before joining to avoid type errors
-  mixed_cols <- c("Round", "Jumper.No.")
-  cols_to_convert <- intersect(mixed_cols, colnames(ids_new[[1]]))
+  # readUrl() swallows per-season errors so partial data is still usable -
+  # but if afltables.com is unreachable every season drops out, leaving an
+  # empty list. Fall back to the stored ids rather than erroring on
+  # `ids_new[[1]]` with a confusing "subscript out of bounds".
+  if (length(ids_new) == 0) {
+    cli::cli_warn(c(
+      "Could not read any player id files from {.url https://afltables.com/afl/stats/}.",
+      "i" = "The site may be unavailable, or you may not have an internet connection.",
+      "i" = "Returning stored player ids, which may be missing the most recent seasons."
+    ))
+    ids_new <- tibble::tibble()
+  } else {
+    # Some DFs have numeric columns as 'chr' and some have them as 'dbl',
+    # so we need to make them consistent before joining to avoid type errors
+    mixed_cols <- c("Round", "Jumper.No.")
+    cols_to_convert <- intersect(mixed_cols, colnames(ids_new[[1]]))
 
-  ids_new <- ids_new %>%
-    purrr::map(~ dplyr::mutate_at(., cols_to_convert, as.character)) %>%
-    purrr::list_rbind(names_to = "Season") %>%
-    dplyr::mutate(
-      Season = stringr::str_remove(.data$Season, "https://afltables.com/afl/stats/"),
-      Season = stringr::str_remove(.data$Season, "_stats.txt"),
-      Season = as.numeric(.data$Season)
-    )
-
-  if (nrow(ids_new) < 1) {
-    return(ids)
+    ids_new <- ids_new %>%
+      purrr::map(~ dplyr::mutate_at(., cols_to_convert, as.character)) %>%
+      purrr::list_rbind(names_to = "Season") %>%
+      dplyr::mutate(
+        Season = stringr::str_remove(.data$Season, "https://afltables.com/afl/stats/"),
+        Season = stringr::str_remove(.data$Season, "_stats.txt"),
+        Season = as.numeric(.data$Season)
+      )
   }
 
-  ids_new <- ids_new %>%
-    dplyr::select(!!col_vars) %>%
-    dplyr::distinct() %>%
-    dplyr::rename(Team.abb = "Team") %>%
-    dplyr::left_join(team_abbr, by = c("Team.abb" = "Team.abb")) %>%
-    dplyr::select(!!col_vars)
-
-  ids_new_min <- min(ids_new$Season)
-  ids_new_max <- max(ids_new$Season)
-
-  ids_old <- ids_old %>%
-    dplyr::filter(.data$Season < ids_new_min | .data$Season > ids_new_max)
-
-  if (nrow(ids_old) < 1) {
-    ids <- ids_new %>%
+  if (nrow(ids_new) < 1) {
+    ids <- ids_old %>%
       dplyr::distinct()
   } else {
-    ids <- dplyr::bind_rows(ids_old, ids_new) %>%
-      dplyr::distinct()
+    ids_new <- ids_new %>%
+      dplyr::select(!!col_vars) %>%
+      dplyr::distinct() %>%
+      dplyr::rename(Team.abb = "Team") %>%
+      dplyr::left_join(team_abbr, by = c("Team.abb" = "Team.abb")) %>%
+      dplyr::select(!!col_vars)
+
+    ids_new_min <- min(ids_new$Season)
+    ids_new_max <- max(ids_new$Season)
+
+    ids_old <- ids_old %>%
+      dplyr::filter(.data$Season < ids_new_min | .data$Season > ids_new_max)
+
+    if (nrow(ids_old) < 1) {
+      ids <- ids_new %>%
+        dplyr::distinct()
+    } else {
+      ids <- dplyr::bind_rows(ids_old, ids_new) %>%
+        dplyr::distinct()
+    }
   }
 
   ### Join fixes

--- a/R/utils-http.R
+++ b/R/utils-http.R
@@ -74,3 +74,35 @@ read_fwf_fitzroy <- function(url, ...) {
     }
   )
 }
+
+#' Read a CSV file from a URL, failing gracefully
+#'
+#' Wraps [readr::read_csv()] so that a network-level failure (host
+#' unreachable, no internet, timeout, non-2xx response) produces an
+#' informative message naming the resource rather than readr's bare
+#' "cannot open the connection", as required by CRAN policy for packages
+#' using internet resources.
+#'
+#' @param url A URL to read.
+#' @param ... Passed through to [readr::read_csv()].
+#' @keywords internal
+#' @noRd
+read_csv_fitzroy <- function(url, ...) {
+  old_ua <- getOption("HTTPUserAgent")
+  options(HTTPUserAgent = fitzroy_user_agent())
+  on.exit(options(HTTPUserAgent = old_ua), add = TRUE)
+
+  tryCatch(
+    readr::read_csv(url, ...),
+    error = function(e) {
+      cli::cli_abort(
+        c(
+          "Could not read data from {.url {url}}.",
+          "i" = "The site may be unavailable, or you may not have an internet connection.",
+          "x" = conditionMessage(e)
+        ),
+        call = NULL
+      )
+    }
+  )
+}

--- a/tests/testthat/helper-afltables.R
+++ b/tests/testthat/helper-afltables.R
@@ -1,0 +1,23 @@
+# Thin, readable afltables wrappers around the source-agnostic network
+# resilience helpers in helper-network.R.
+
+#' Skip if afltables.com is not reachable from this environment
+#' @keywords internal
+#' @noRd
+skip_if_afltables_unreachable <- function() {
+  skip_if_source_unreachable("https://afltables.com", "afltables.com")
+}
+
+#' Run test code, skipping instead of failing on an afltables network error
+#' @keywords internal
+#' @noRd
+afltables_resilient <- function(expr) {
+  network_resilient(expr, source = "afltables.com")
+}
+
+#' Skip if an afltables fetch silently came back empty
+#' @keywords internal
+#' @noRd
+skip_if_afltables_empty <- function(result) {
+  skip_if_empty(result, source = "afltables.com")
+}

--- a/tests/testthat/helper-footywire.R
+++ b/tests/testthat/helper-footywire.R
@@ -1,90 +1,23 @@
+# Thin, readable footywire wrappers around the source-agnostic network
+# resilience helpers in helper-network.R.
+
+#' Skip if footywire.com is not reachable from this environment
+#' @keywords internal
+#' @noRd
 skip_if_footywire_unreachable <- function() {
-  testthat::skip_if_offline()
-  testthat::skip_on_cran()
-
-  # Use the same fetch path the package itself uses (rvest/xml2) rather than
-  # httr - footywire's bot protection 406s plain httr::GET() requests even
-  # when the site is otherwise reachable, which would cause false skips.
-  reachable <- tryCatch(
-    {
-      rvest::read_html("https://www.footywire.com")
-      TRUE
-    },
-    error = function(e) FALSE
-  )
-
-  testthat::skip_if_not(reachable, "footywire.com is not reachable from this environment")
+  skip_if_source_unreachable("https://www.footywire.com", "footywire.com")
 }
 
 #' Run test code, skipping instead of failing on a footywire network error
-#'
-#' An initial reachability check (`skip_if_footywire_unreachable()`) only
-#' samples one moment - footywire's bot protection can start rate-limiting
-#' or blocking a CI runner's IP partway through a test run even when that
-#' check passed. This wraps a test body so any network-level failure while
-#' it runs (a dropped connection, a non-2xx HTTP response, a timeout) is
-#' skipped instead of failing the build. Genuine assertion failures and
-#' non-network errors still propagate and fail the test normally.
-#'
-#' Uses `withCallingHandlers()` rather than `tryCatch()` deliberately:
-#' testthat's own expectation failures (e.g. a genuinely failed
-#' `expect_s3_class()`) are conditions of class `c("expectation_failure",
-#' "expectation", "error", "condition")`, and testthat recovers from them by
-#' invoking a `muffle_expectation` restart established around the whole
-#' test. `tryCatch()` unwinds the stack before its handler runs, which
-#' destroys that restart and breaks testthat's ability to continue - so
-#' expectation failures must be left completely untouched here.
+#' @keywords internal
+#' @noRd
 footywire_resilient <- function(expr) {
-  withCallingHandlers(
-    expr,
-    error = function(e) {
-      # Never intervene on testthat's own expectation failures - let them
-      # propagate so testthat's normal failure-recording machinery handles
-      # them.
-      if (inherits(e, "expectation")) {
-        return(invisible(NULL))
-      }
-
-      msg <- conditionMessage(e)
-      network_pattern <- paste(
-        "cannot open the connection",
-        "could not read page",
-        "failed to load page",
-        "couldn't find basic table",
-        "timeout was reached",
-        "could not resolve host",
-        "failed to connect",
-        "ssl certificate problem",
-        "recv failure",
-        "connection reset",
-        "empty reply from server",
-        "http [45][0-9]{2}",
-        sep = "|"
-      )
-      is_network_error <- inherits(e, "httr2_http") ||
-        grepl(network_pattern, msg, ignore.case = TRUE)
-
-      if (is_network_error) {
-        testthat::skip(paste("footywire network error:", msg))
-      }
-      # Not a network error and not an expectation failure: do nothing so
-      # the error continues propagating normally and fails the test.
-    }
-  )
+  network_resilient(expr, source = "footywire.com")
 }
 
 #' Skip if a footywire fetch silently came back empty
-#'
-#' Some fetchers (e.g. `fetch_scores()`) swallow per-page network errors
-#' internally (`tryCatch(..., error = function(e) NULL)` then `next`) so
-#' they can still return partial data when only some pages fail. That means
-#' a footywire block/outage during a test run doesn't throw - it just
-#' produces an empty/NULL result, which `footywire_resilient()` can't
-#' detect since no error is ever raised. Call this right after such a fetch
-#' to treat "got nothing back" as a network skip rather than a real
-#' assertion failure.
+#' @keywords internal
+#' @noRd
 skip_if_footywire_empty <- function(result) {
-  if (!inherits(result, "data.frame") || nrow(result) == 0) {
-    testthat::skip("footywire returned no data (likely blocked/unreachable in this environment)")
-  }
+  skip_if_empty(result, source = "footywire.com")
 }

--- a/tests/testthat/helper-network.R
+++ b/tests/testthat/helper-network.R
@@ -1,0 +1,169 @@
+# Shared helpers for keeping tests resilient to a live data source being
+# briefly unreachable.
+#
+# fitzRoy's tests hit live sites (afltables.com, footywire.com, ...). A CI
+# runner losing access to one of them for a few seconds should skip the
+# affected tests, not fail the build - re-running an unchanged commit
+# otherwise goes green, which is noise a real regression could hide in.
+#
+# These are source-agnostic; thin, readable per-source wrappers live in
+# helper-afltables.R and helper-footywire.R.
+
+#' Message patterns that indicate a network-level failure
+#'
+#' Messages produced when a request fails at the network level (rather than
+#' because the code under test is wrong), including the wrappers fitzRoy
+#' puts around them (`read_fwf_fitzroy()`, `fetch_team_stats()` etc).
+#' @keywords internal
+#' @noRd
+network_error_pattern <- function() {
+  paste(
+    "cannot open the connection",
+    "could not read page",
+    "could not read data from",
+    "could not access",
+    "failed to load page",
+    "failed to open",
+    "couldn't find basic table",
+    "timeout was reached",
+    "timed out",
+    "could not resolve host",
+    "failed to connect",
+    "ssl certificate problem",
+    "recv failure",
+    "connection reset",
+    "empty reply from server",
+    "http [45][0-9]{2}",
+    sep = "|"
+  )
+}
+
+#' Name the source an error message actually came from
+#'
+#' `footywire_resilient()` used to report any network error it saw as a
+#' footywire one, so an afltables outage surfaced as
+#' "footywire network error: Could not read data from
+#' <https://afltables.com/...>". fitzRoy's network errors nearly always
+#' name the URL they failed on, so prefer the host in the message over the
+#' label of whichever wrapper happened to catch it.
+#'
+#' @param msg An error message.
+#' @param default Label to use when the message names no URL.
+#' @keywords internal
+#' @noRd
+network_error_source <- function(msg, default) {
+  match <- regmatches(msg, regexpr("https?://[^/[:space:]>'\"]+", msg))
+  if (length(match) == 0) {
+    return(default)
+  }
+  sub("^www\\.", "", sub("^https?://", "", match[[1]]))
+}
+
+#' Skip if a data source is not reachable from this environment
+#'
+#' Reachability precheck using the same fetch path the package itself uses
+#' (`read_html_fitzroy()`, i.e. xml2/rvest carrying fitzRoy's User-Agent)
+#' rather than a plain `httr::GET()` - footywire's bot protection 406s
+#' requests with a generic User-Agent even when the site is otherwise
+#' reachable, which would cause false skips.
+#'
+#' Note `skip_if_offline()` alone is not enough: it pings r-project.org,
+#' which stays reachable while afltables.com or footywire.com is not.
+#'
+#' @param url URL to check.
+#' @param source Human-readable name of the source, used in the skip message.
+#' @keywords internal
+#' @noRd
+skip_if_source_unreachable <- function(url, source = url) {
+  testthat::skip_if_offline()
+  testthat::skip_on_cran()
+
+  reachable <- tryCatch(
+    {
+      read_html_fitzroy(url)
+      TRUE
+    },
+    error = function(e) FALSE
+  )
+
+  testthat::skip_if_not(reachable, paste(source, "is not reachable from this environment"))
+}
+
+#' Run test code, skipping instead of failing on a network error
+#'
+#' A reachability check (`skip_if_source_unreachable()`) only samples one
+#' moment - a site can start timing out, or start rate-limiting a CI
+#' runner's IP, partway through a test run even when that check passed.
+#' This wraps a test body so any network-level failure while it runs (a
+#' dropped connection, a non-2xx HTTP response, a timeout) is skipped
+#' instead of failing the build. Genuine assertion failures and non-network
+#' errors still propagate and fail the test normally.
+#'
+#' Uses `withCallingHandlers()` rather than `tryCatch()` deliberately:
+#' testthat's own expectation failures (e.g. a genuinely failed
+#' `expect_s3_class()`) are conditions of class `c("expectation_failure",
+#' "expectation", "error", "condition")`, and testthat recovers from them by
+#' invoking a `muffle_expectation` restart established around the whole
+#' test. `tryCatch()` unwinds the stack before its handler runs, which
+#' destroys that restart and breaks testthat's ability to continue - so
+#' expectation failures must be left completely untouched here.
+#'
+#' @param expr Test code to run.
+#' @param source Human-readable name of the source, used in the skip message
+#'   when the error itself names no URL.
+#' @keywords internal
+#' @noRd
+network_resilient <- function(expr, source = "unknown source") {
+  withCallingHandlers(
+    expr,
+    error = function(e) {
+      # Never intervene on testthat's own expectation failures - let them
+      # propagate so testthat's normal failure-recording machinery handles
+      # them.
+      if (inherits(e, "expectation")) {
+        return(invisible(NULL))
+      }
+
+      msg <- conditionMessage(e)
+      is_network_error <- inherits(e, "httr2_http") ||
+        grepl(network_error_pattern(), msg, ignore.case = TRUE)
+
+      if (is_network_error) {
+        testthat::skip(paste0(
+          "network error (", network_error_source(msg, source), "): ", msg
+        ))
+      }
+      # Not a network error and not an expectation failure: do nothing so
+      # the error continues propagating normally and fails the test.
+    }
+  )
+}
+
+#' Skip if a fetch silently came back empty
+#'
+#' Some code swallows per-request network errors internally so it can still
+#' return partial data when only some pages fail (`fetch_scores()` does this
+#' per page; `get_afltables_urls()` and `get_afltables_player_ids()` do it
+#' per season). That means an outage during a test run doesn't throw - it
+#' just produces an empty/NULL result, which `network_resilient()` can't
+#' detect since no error is ever raised. Call this right after such a fetch
+#' to treat "got nothing back" as a network skip rather than a real
+#' assertion failure.
+#'
+#' @param result The result of a fetch: a data frame, list or vector.
+#' @param source Human-readable name of the source, used in the skip message.
+#' @keywords internal
+#' @noRd
+skip_if_empty <- function(result, source = "the data source") {
+  is_empty <- if (inherits(result, "data.frame")) {
+    nrow(result) == 0
+  } else {
+    is.null(result) || length(result) == 0
+  }
+
+  if (is_empty) {
+    testthat::skip(paste(
+      source, "returned no data (likely blocked/unreachable in this environment)"
+    ))
+  }
+}

--- a/tests/testthat/test-fetch-ladder.R
+++ b/tests/testthat/test-fetch-ladder.R
@@ -2,72 +2,85 @@ test_that("fetch_ladder_afl works for various inputs", {
   testthat::skip_if_offline()
   testthat::skip_on_cran()
 
-  expect_s3_class(fetch_ladder_afl(2020, 1, comp = "AFLM"), "tbl")
+  network_resilient(
+    {
+      expect_s3_class(fetch_ladder_afl(2020, 1, comp = "AFLM"), "tbl")
 
-  # change year
-  expect_s3_class(fetch_ladder_afl(2018, 1, comp = "AFLM"), "tbl")
-  fetch_ladder_afl(2000, 1, comp = "AFLM") %>%
-    expect_warning() %>%
-    suppressWarnings()
+      # change year
+      expect_s3_class(fetch_ladder_afl(2018, 1, comp = "AFLM"), "tbl")
+      fetch_ladder_afl(2000, 1, comp = "AFLM") %>%
+        expect_warning() %>%
+        suppressWarnings()
 
-  # change round number
-  lad <- fetch_ladder_afl(2020, round_number = 2)
-  expect_s3_class(lad, "tbl")
-  expect_equal(max(lad$round_number), 2)
-  expect_equal(min(lad$round_number), 2)
+      # change round number
+      lad <- fetch_ladder_afl(2020, round_number = 2)
+      expect_s3_class(lad, "tbl")
+      expect_equal(max(lad$round_number), 2)
+      expect_equal(min(lad$round_number), 2)
 
-  lad <- fetch_ladder_afl(2021, comp = "AFLW", round_number = 5)
-  expect_s3_class(lad, "tbl")
-  expect_equal(max(lad$round_number), 5)
-  expect_equal(min(lad$round_number), 5)
+      lad <- fetch_ladder_afl(2021, comp = "AFLW", round_number = 5)
+      expect_s3_class(lad, "tbl")
+      expect_equal(max(lad$round_number), 5)
+      expect_equal(min(lad$round_number), 5)
 
-  expect_warning(dat <- fetch_ladder_afl(2020, round_number = 50))
-  expect_null(dat)
+      expect_warning(dat <- fetch_ladder_afl(2020, round_number = 50))
+      expect_null(dat)
 
-  # change comp
-  expect_s3_class(fetch_ladder_afl(2020, round_number = 1, comp = "AFLW"), "tbl")
-  expect_error(fetch_ladder_afl(2020, round_number = 1, comp = "test"))
+      # change comp
+      expect_s3_class(fetch_ladder_afl(2020, round_number = 1, comp = "AFLW"), "tbl")
+      expect_error(fetch_ladder_afl(2020, round_number = 1, comp = "test"))
+    },
+    source = "AFL.com.au"
+  )
 })
 
 test_that("get_match_results returns data frame with required variables", {
-  testthat::skip_if_offline()
-  testthat::skip_on_cran()
+  skip_if_afltables_unreachable()
 
-  yr <- Sys.Date() %>%
-    format("%Y") %>%
-    as.numeric()
+  afltables_resilient({
+    yr <- Sys.Date() %>%
+      format("%Y") %>%
+      as.numeric()
 
-  res_df <- fetch_results_afltables(yr - 1)
-  expect_s3_class(fetch_ladder_afltables(yr - 1, 1, match_results_df = res_df), "tbl")
+    res_df <- fetch_results_afltables(yr - 1)
+    skip_if_afltables_empty(res_df)
+    expect_s3_class(fetch_ladder_afltables(yr - 1, 1, match_results_df = res_df), "tbl")
 
-  # change year
-  res_df_older <- fetch_results_afltables(yr - 2)
-  expect_s3_class(fetch_ladder_afltables(yr - 2, 1, match_results_df = res_df_older), "tbl")
+    # change year
+    res_df_older <- fetch_results_afltables(yr - 2)
+    skip_if_afltables_empty(res_df_older)
+    expect_s3_class(fetch_ladder_afltables(yr - 2, 1, match_results_df = res_df_older), "tbl")
 
-  # change round number
-  expect_s3_class(fetch_ladder_afltables(yr - 1, 2, match_results_df = res_df), "tbl")
-  expect_error(fetch_ladder_afltables(yr - 1, 50, match_results_df = res_df))
+    # change round number
+    expect_s3_class(fetch_ladder_afltables(yr - 1, 2, match_results_df = res_df), "tbl")
+    expect_error(fetch_ladder_afltables(yr - 1, 50, match_results_df = res_df))
+  })
 })
 
 test_that("fetch_ladder_squiggle returns data frame with required variables", {
   testthat::skip_if_offline()
   testthat::skip_on_cran()
 
-  yr <- Sys.Date() %>%
-    format("%Y") %>%
-    as.numeric()
+  network_resilient(
+    {
+      yr <- Sys.Date() %>%
+        format("%Y") %>%
+        as.numeric()
 
-  expect_s3_class(fetch_ladder_squiggle(), "tbl")
+      expect_s3_class(fetch_ladder_squiggle(), "tbl")
 
-  # change year
-  expect_s3_class(fetch_ladder_squiggle(yr - 2, 1), "tbl")
-  expect_s3_class(fetch_ladder_squiggle(yr + 1, 1), "tbl")
+      # change year
+      expect_s3_class(fetch_ladder_squiggle(yr - 2, 1), "tbl")
+      expect_s3_class(fetch_ladder_squiggle(yr + 1, 1), "tbl")
 
 
-  # change round number
-  expect_s3_class(fetch_ladder_squiggle(yr - 1, 10), "tbl")
-  expect_s3_class(fetch_ladder_squiggle(yr - 1, 20), "tbl")
-  expect_s3_class(fetch_ladder_squiggle(yr - 1), "tbl")
+      # change round number
+      expect_s3_class(fetch_ladder_squiggle(yr - 1, 10), "tbl")
+      expect_s3_class(fetch_ladder_squiggle(yr - 1, 20), "tbl")
+      expect_s3_class(fetch_ladder_squiggle(yr - 1), "tbl")
+    },
+    source = "squiggle"
+  )
 })
 
 test_that("fetch_ladder works", {
@@ -75,24 +88,34 @@ test_that("fetch_ladder works", {
   testthat::skip_on_cran()
 
   # Test each source works
-  expect_s3_class(fetch_ladder(2020, round = 1, source = "squiggle"), "tbl")
-  expect_s3_class(fetch_ladder(2020, round = 1, source = "afltables"), "tbl")
-  expect_warning(fetch_ladder(2020, round = 1, source = "footywire"))
+  network_resilient(
+    {
+      expect_s3_class(fetch_ladder(2020, round = 1, source = "squiggle"), "tbl")
+      expect_s3_class(fetch_ladder(2020, round = 1, source = "afltables"), "tbl")
+      expect_warning(fetch_ladder(2020, round = 1, source = "footywire"))
+    },
+    source = "squiggle/afltables/footywire"
+  )
 })
 
 test_that("fetch_ladder works for non-AFL leagues", {
   testthat::skip_if_offline()
   testthat::skip_on_cran()
 
-  # Test each source works
-  expect_s3_class(fetch_ladder(2022, round_number = 1, source = "AFL", comp = "WAFL"), "tbl")
-  expect_s3_class(fetch_ladder(2022, round_number = 1, source = "AFL", comp = "VFL"), "tbl")
-  expect_s3_class(fetch_ladder(2022, round_number = 1, source = "AFL", comp = "VFLW"), "tbl")
-  expect_s3_class(fetch_ladder(2022, round_number = 1, source = "AFL", comp = "U18B"), "tbl")
-  expect_s3_class(fetch_ladder(2019, round_number = 1, source = "AFL", comp = "U18G"), "tbl")
+  network_resilient(
+    {
+      # Test each source works
+      expect_s3_class(fetch_ladder(2022, round_number = 1, source = "AFL", comp = "WAFL"), "tbl")
+      expect_s3_class(fetch_ladder(2022, round_number = 1, source = "AFL", comp = "VFL"), "tbl")
+      expect_s3_class(fetch_ladder(2022, round_number = 1, source = "AFL", comp = "VFLW"), "tbl")
+      expect_s3_class(fetch_ladder(2022, round_number = 1, source = "AFL", comp = "U18B"), "tbl")
+      expect_s3_class(fetch_ladder(2019, round_number = 1, source = "AFL", comp = "U18G"), "tbl")
 
-  # Check for warnings thrown
-  fetch_ladder(2022, round_number = 1, source = "AFL", comp = "U18G") %>%
-    expect_warning() %>%
-    suppressWarnings()
+      # Check for warnings thrown
+      fetch_ladder(2022, round_number = 1, source = "AFL", comp = "U18G") %>%
+        expect_warning() %>%
+        suppressWarnings()
+    },
+    source = "AFL.com.au"
+  )
 })

--- a/tests/testthat/test-helpers-afltables-playerstats.R
+++ b/tests/testthat/test-helpers-afltables-playerstats.R
@@ -1,39 +1,53 @@
 test_that("scape_afltables_ works", {
-  testthat::skip_if_offline()
-  testthat::skip_on_cran()
+  skip_if_afltables_unreachable()
 
-  url_new <- "https://afltables.com/afl/stats/games/2018/030820180812.html"
-  url_old <- "https://afltables.com/afl/stats/games/1897/030618970508.html"
-  url_extra_time <- "https://afltables.com/afl/stats/games/2007/041820070914.html"
-  expect_type(scrape_afltables_match(url_new), "list")
-  expect_type(scrape_afltables_match(url_old), "list")
-  expect_type(scrape_afltables_match(url_extra_time), "list")
-  expect_error(scrape_afltables_match())
-  expect_error(scrape_afltables_match(1))
-  expect_error(scrape_afltables_match("a"))
+  afltables_resilient({
+    url_new <- "https://afltables.com/afl/stats/games/2018/030820180812.html"
+    url_old <- "https://afltables.com/afl/stats/games/1897/030618970508.html"
+    url_extra_time <- "https://afltables.com/afl/stats/games/2007/041820070914.html"
+    expect_type(scrape_afltables_match(url_new), "list")
+    expect_type(scrape_afltables_match(url_old), "list")
+    expect_type(scrape_afltables_match(url_extra_time), "list")
+    expect_error(scrape_afltables_match())
+    expect_error(scrape_afltables_match(1))
+    expect_error(scrape_afltables_match("a"))
+  })
 })
 
 test_that("get_afltables_urls works", {
-  testthat::skip_if_offline()
-  testthat::skip_on_cran()
+  skip_if_afltables_unreachable()
 
-  expect_type(get_afltables_urls("2018-01-01", "2018-06-01"), "character")
-  expect_type(get_afltables_urls("1930-01-01", "1930-12-01"), "character")
-  expect_error(get_afltables_urls())
-  expect_error(suppresWarnings(get_afltables_urls("a")))
+  afltables_resilient({
+    # get_afltables_urls() swallows per-season failures, so an outage gives
+    # back an empty vector rather than throwing - treat that as a skip.
+    urls_new <- get_afltables_urls("2018-01-01", "2018-06-01")
+    skip_if_afltables_empty(urls_new)
+    expect_type(urls_new, "character")
+
+    urls_old <- get_afltables_urls("1930-01-01", "1930-12-01")
+    skip_if_afltables_empty(urls_old)
+    expect_type(urls_old, "character")
+
+    expect_error(get_afltables_urls())
+    expect_error(suppresWarnings(get_afltables_urls("a")))
+  })
 })
 
 test_that("get_afltables_player_ids works", {
-  testthat::skip_if_offline()
-  testthat::skip_on_cran()
+  skip_if_afltables_unreachable()
 
-  max_seas <- Sys.Date() %>%
-    format("%Y") %>%
-    as.numeric()
+  afltables_resilient({
+    max_seas <- Sys.Date() %>%
+      format("%Y") %>%
+      as.numeric()
 
-  expect_type(get_afltables_player_ids(1897:2020), "list")
-  expect_type(get_afltables_player_ids(2017), "list")
-  expect_type(get_afltables_player_ids(2021), "list")
-  expect_error(get_afltables_player_ids())
-  expect_error(suppressWarnings(get_afltables_player_ids("a")))
+    ids <- get_afltables_player_ids(1897:2020)
+    skip_if_afltables_empty(ids)
+    expect_type(ids, "list")
+
+    expect_type(get_afltables_player_ids(2017), "list")
+    expect_type(get_afltables_player_ids(2021), "list")
+    expect_error(get_afltables_player_ids())
+    expect_error(suppressWarnings(get_afltables_player_ids("a")))
+  })
 })

--- a/tests/testthat/test-helpers-afltables.R
+++ b/tests/testthat/test-helpers-afltables.R
@@ -16,9 +16,13 @@ test_that("replace_venues returns corrected venues", {
 })
 
 test_that("conver_results works", {
-  testthat::skip_if_offline()
-  testthat::skip_on_cran()
+  skip_if_afltables_unreachable()
 
-  expect_type(convert_results(fetch_results_afltables(2020)), "list")
-  expect_error(convert_results("a"))
+  afltables_resilient({
+    results <- fetch_results_afltables(2020)
+    skip_if_afltables_empty(results)
+
+    expect_type(convert_results(results), "list")
+    expect_error(convert_results("a"))
+  })
 })

--- a/tests/testthat/test-helpers-general.R
+++ b/tests/testthat/test-helpers-general.R
@@ -1,7 +1,4 @@
 test_that("check_season works for various inputs", {
-  testthat::skip_if_offline()
-  testthat::skip_on_cran()
-
   expect_equal(check_season(2000), 2000)
   expect_equal(check_season(2020), 2020)
   expect_gte(check_season(NULL), Sys.Date() %>% format("%Y") %>% as.numeric())
@@ -11,9 +8,6 @@ test_that("check_season works for various inputs", {
 })
 
 test_that("check_comp works for various inputs", {
-  testthat::skip_if_offline()
-  testthat::skip_on_cran()
-
   expect_equal(check_comp("AFLW"), "AFLW")
   expect_equal(check_comp("AFLM"), "AFLM")
   expect_equal(check_comp("VFL"), "VFL")
@@ -24,9 +18,6 @@ test_that("check_comp works for various inputs", {
 })
 
 test_that("check_source works for various inputs", {
-  testthat::skip_if_offline()
-  testthat::skip_on_cran()
-
   # successes
   expect_equal(check_source("AFL"), "AFL")
   expect_equal(check_source("afltables"), "afltables")
@@ -41,9 +32,6 @@ test_that("check_source works for various inputs", {
 })
 
 test_that("check_source works for various inputs", {
-  testthat::skip_if_offline()
-  testthat::skip_on_cran()
-
   # AFLM
   expect_invisible(check_comp_source("AFLM", "AFL"))
   expect_invisible(check_comp_source("AFLM", "afltables"))
@@ -66,9 +54,6 @@ test_that("check_source works for various inputs", {
 })
 
 test_that("return_start_end_date works for various inputs", {
-  testthat::skip_if_offline()
-  testthat::skip_on_cran()
-
   # 1 year
   x <- return_start_end_dates(2018)
   expect_equal(x$start_date, as.POSIXct("2018-01-01", tz = "UTC"))


### PR DESCRIPTION
Fixes #292.

`R CMD check` has failed on `main` in 8 of the last 9 runs, almost always because afltables.com or footywire.com was briefly unreachable from a GitHub runner rather than because of a code defect. The footywire tests were wrapped to skip on network failure; the afltables tests were not, so they hard-failed instead.

## What changed

**Shared helpers.** The three footywire helpers are generalised into source-agnostic equivalents in `tests/testthat/helper-network.R`:

| Helper | Purpose |
|---|---|
| `skip_if_source_unreachable(url, source)` | Reachability precheck via the same fetch path the package uses (`read_html_fitzroy()`, carrying fitzRoy's User-Agent) - a plain `httr::GET()` gets 406'd by footywire's bot protection and would cause false skips. |
| `network_resilient(expr, source)` | Wraps a test body; network-level failures mid-run become skips. |
| `skip_if_empty(result, source)` | For fetchers that swallow errors internally and return empty rather than throwing. Handles data frames, lists, vectors and `NULL`. |

`helper-footywire.R` and the new `helper-afltables.R` are now thin wrappers over these, so existing call sites read the same.

`network_resilient()` keeps `withCallingHandlers()` - `tryCatch()` unwinds the stack before its handler runs, which destroys the `muffle_expectation` restart testthat uses to recover from expectation failures. The explanatory comment moved across with the code.

**Correct source labelling.** `footywire_resilient()` was catching afltables errors and reporting them as `footywire network error: Could not read data from <https://afltables.com/...>`. Skips are now labelled from the host named in the error message, falling back to the wrapper's declared source only when the message names no URL.

**Applied to the four uncovered files.** `test-helpers-afltables-playerstats.R`, `test-fetch-ladder.R` and `test-helpers-afltables.R` are now wrapped. `test-helpers-general.R` turned out to make no network calls at all (its "afltables refs" are string literals passed to `check_source()`), so the `skip_if_offline()` / `skip_on_cran()` guards there were spurious - removing them means those 38 assertions now actually run on CRAN and offline instead of skipping.

**Graceful degradation in the package.** Two of the eleven failures on the #290 run arrived as ordinary errors, because the network failure was swallowed upstream leaving an empty result:

- `get_afltables_urls()` now returns `character(0)` with an informative warning instead of ``Must supply `.init` when `.x` is empty``.
- `get_afltables_player_ids()` now falls back to the stored player ids with a warning instead of `subscript out of bounds` on `ids_new[[1]]`. (This also fixes a latent bug: the pre-existing `if (nrow(ids_new) < 1) return(ids)` referenced `ids` before it was assigned.)
- The stored player id file is read through a new `read_csv_fitzroy()`, which names the resource on failure rather than surfacing readr's bare "cannot open the connection" - the same CRAN "fail gracefully" point that prompted `read_fwf_fitzroy()` in #290.

## Verification

Run against the package installed to a temp lib (`devtools::load_all()` + parallel workers fails locally), serially, comparing the four affected files before and after.

- **Network up, `NOT_CRAN=true`:** 87 pass / 0 fail / **0 skip** - identical to the same files on `main`. The wrappers do not skip anything when the sources are reachable.
- **Simulated outage** (all traffic pointed at a dead proxy): `main` gives **8 hard errors**; this branch gives **0 errors, 9 clean skips**, with correct labels (`network error (afltables.com|squiggle|AFL.com.au): ...`), and the 11 offline assertions in those files still run and pass.
- **`NOT_CRAN=false`:** the 9 network tests skip with "On CRAN", and the 38 pure-validation assertions in `test-helpers-general.R` run and pass.
- **Helper behaviour, unit-tested directly:** a network error (using the exact message from the #290 CI log) becomes a correctly-labelled skip; a genuine `expect_true(FALSE)` inside `afltables_resilient()` is still recorded as a failure *and testthat continues to the next expectation*, confirming the `muffle_expectation` restart survives; non-network errors still propagate.
- **No behaviour change with the network up:** `get_afltables_urls()` and `get_afltables_player_ids()` return output `identical()` to `main`'s.
- **Outage of afltables only** (GitHub reachable): `get_afltables_player_ids(2017)` returns the stored ids with a warning, instead of `subscript out of bounds`.
- `R CMD check --no-tests --no-vignettes`: all R code/doc checks OK (the two WARNINGs are vignette artifacts of `--no-build-vignettes`).

One thing spotted but not touched, as it is unrelated and pre-existing: `test-fetch-fixture.R`, `test-fetch-lineup.R` and `test-fetch-results.R` have `expect_warning()` assertions on `lifecycle::deprecate_warn()` deprecations, which only warn once per session. They produce the same 12 failures on `main` and on this branch when a whole file runs in one process.

🤖 Generated with [Claude Code](https://claude.com/claude-code)